### PR TITLE
Remove port number validation from MongoDB provider configuration

### DIFF
--- a/docs/resources/database_collection.md
+++ b/docs/resources/database_collection.md
@@ -11,6 +11,7 @@ resource "mongodb_db_collection" "collection_1" {
   db = "my_database"
   name = "example"
   record_pre_images = true
+  change_stream_pre_and_post_images = true
   deletion_protection = true
 }
 ```
@@ -20,6 +21,7 @@ resource "mongodb_db_collection" "collection_1" {
 * `db` (Required, string) – Database in which the collection will be created.
 * `name` (Required, string) – Collection name.
 * `record_pre_images` (Optional, bool, default: false) – Control collection's pre-image support.
+* `change_stream_pre_and_post_images` (Optional, bool, default: false) – Enable capturing of full document before and after images for change streams.
 * `deletion_protection` (Optional, bool, default: false) – Prevent collection from being dropped.
 
 ## Attributes Reference

--- a/mongodb/provider.go
+++ b/mongodb/provider.go
@@ -28,7 +28,6 @@ func Provider() *schema.Provider {
 			"port": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.IsPortNumber),
 				DefaultFunc:      schema.EnvDefaultFunc("MONGO_PORT", "27017"),
 				Description:      "The mongodb server port",
 			},


### PR DESCRIPTION
Eliminate the validation for the port number in the MongoDB provider configuration to allow more flexibility in the input.