### PR TITLE
Remove mongo-express service and add acceptance tests for MongoDB roles

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,20 +18,5 @@ services:
       - 27017:27017
     networks:
       - network
-  mongo-express:
-    image: mongo-express
-    container_name: mongo-express
-    ports:
-      - 8081:8081
-    environment:
-      ME_CONFIG_MONGODB_URL: mongodb://root:root@mongo:27017/
-      ME_CONFIG_MONGODB_ADMINUSERNAME: root
-      ME_CONFIG_MONGODB_ADMINPASSWORD: root
-    links:
-      - mongo:mongo
-    networks:
-      - network
-    depends_on:
-      - mongo
 volumes:
   mongo_data: {}

--- a/mongodb/resource_db_role.go
+++ b/mongodb/resource_db_role.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -217,10 +218,15 @@ func resourceDatabaseRoleRead(ctx context.Context, data *schema.ResourceData, i 
 	privileges := make([]interface{}, len(result.Roles[0].Privileges))
 
 	for i, s := range result.Roles[0].Privileges {
+		// Sort actions to ensure consistent ordering
+		actions := make([]string, len(s.Actions))
+		copy(actions, s.Actions)
+		sort.Strings(actions)
+		
 		privileges[i] = map[string]interface{}{
 			"db":         s.Resource.Db,
 			"collection": s.Resource.Collection,
-			"actions":    s.Actions,
+			"actions":    actions,
 		}
 	}
 	dataSetError = data.Set("privilege", privileges)

--- a/mongodb/resource_db_role_test.go
+++ b/mongodb/resource_db_role_test.go
@@ -1,0 +1,229 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestAccMongoDBRole_Basic(t *testing.T) {
+	var roleName = acctest.RandomWithPrefix("tf-acc-role")
+	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBRoleBasic(databaseName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "privilege.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMongoDBRole_WithInheritedRoles(t *testing.T) {
+	var roleName = acctest.RandomWithPrefix("tf-acc-role")
+	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBRoleWithInheritedRoles(databaseName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "privilege.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "inherited_role.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccMongoDBRole_MultiplePrivileges(t *testing.T) {
+	var roleName = acctest.RandomWithPrefix("tf-acc-role")
+	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBRoleMultiplePrivileges(databaseName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "database", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "privilege.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBRoleExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := testAccProvider.Meta().(*MongoDatabaseConfiguration)
+		client, err := MongoClientInit(config)
+		if err != nil {
+			return fmt.Errorf("error connecting to database: %s", err)
+		}
+
+		roleName, database, err := resourceDatabaseRoleParseId(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error parsing ID: %s", err)
+		}
+
+		result, err := getRole(client, roleName, database)
+		if err != nil {
+			return fmt.Errorf("error getting role: %s", err)
+		}
+
+		if len(result.Roles) == 0 {
+			return fmt.Errorf("role not found: %s", roleName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBRoleDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*MongoDatabaseConfiguration)
+	client, err := MongoClientInit(config)
+	if err != nil {
+		return fmt.Errorf("error connecting to database: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodb_db_role" {
+			continue
+		}
+
+		roleName, database, err := resourceDatabaseRoleParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		db := client.Database(database)
+		result := db.RunCommand(context.Background(), bson.D{
+			{Key: "rolesInfo", Value: roleName},
+			{Key: "showPrivileges", Value: true},
+		})
+
+		if result.Err() != nil {
+			// If there's an error getting the role, it might be deleted
+			continue
+		}
+
+		var roleResult SingleResultGetRole
+		if err := result.Decode(&roleResult); err != nil {
+			return err
+		}
+
+		if len(roleResult.Roles) > 0 {
+			return fmt.Errorf("role still exists: %s", roleName)
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBRoleBasic(dbName, roleName string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_role" "test" {
+  database = "%s"
+  name     = "%s"
+  
+  privilege {
+    db         = "%s"
+    collection = "test_collection"
+    actions    = ["find", "insert", "update"]
+  }
+}
+`, dbName, roleName, dbName)
+}
+
+func testAccMongoDBRoleWithInheritedRoles(dbName, roleName string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_role" "test" {
+  database = "%s"
+  name     = "%s"
+  
+  privilege {
+    db         = "%s"
+    collection = "test_collection"
+    actions    = ["find", "insert"]
+  }
+  
+  inherited_role {
+    db   = "%s"
+    role = "read"
+  }
+}
+`, dbName, roleName, dbName, dbName)
+}
+
+func testAccMongoDBRoleMultiplePrivileges(dbName, roleName string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_role" "test" {
+  database = "%s"
+  name     = "%s"
+  
+  privilege {
+    db         = "%s"
+    collection = "collection1"
+    actions    = ["find", "insert"]
+  }
+  
+  privilege {
+    db         = "%s"
+    collection = "collection2"
+    actions    = ["find", "remove", "update"]
+  }
+}
+`, dbName, roleName, dbName, dbName)
+}

--- a/mongodb/resource_db_user.go
+++ b/mongodb/resource_db_user.go
@@ -161,6 +161,10 @@ func resourceDatabaseUserRead(ctx context.Context, data *schema.ResourceData, i 
 	if dataSetError != nil {
 		return diag.Errorf("error setting auth_db : %s ", dataSetError)
 	}
+	dataSetError = data.Set("name", username)
+	if dataSetError != nil {
+		return diag.Errorf("error setting name : %s ", dataSetError)
+	}
 	dataSetError = data.Set("password", data.Get("password"))
 	if dataSetError != nil {
 		return diag.Errorf("error setting password : %s ", dataSetError)

--- a/mongodb/resource_db_user_test.go
+++ b/mongodb/resource_db_user_test.go
@@ -1,0 +1,264 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestAccMongoDBUser_Basic(t *testing.T) {
+	var userName = acctest.RandomWithPrefix("tf-acc-user")
+	var password = acctest.RandomWithPrefix("tf-acc-pwd")
+	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBUserBasic(databaseName, userName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_database", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "role.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccMongoDBUser_MultipleRoles(t *testing.T) {
+	var userName = acctest.RandomWithPrefix("tf-acc-user")
+	var password = acctest.RandomWithPrefix("tf-acc-pwd")
+	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBUserMultipleRoles(databaseName, userName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_database", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "role.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccMongoDBUser_Update(t *testing.T) {
+	var userName = acctest.RandomWithPrefix("tf-acc-user")
+	var password = acctest.RandomWithPrefix("tf-acc-pwd")
+	var updatedPassword = acctest.RandomWithPrefix("tf-acc-pwd-upd")
+	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBUserBasic(databaseName, userName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_database", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "role.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBUserBasic(databaseName, userName, updatedPassword),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_database", databaseName),
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "password", updatedPassword),
+					resource.TestCheckResourceAttr(resourceName, "role.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMongoDBUser_AdminDatabase(t *testing.T) {
+	var userName = acctest.RandomWithPrefix("tf-acc-user")
+	var password = acctest.RandomWithPrefix("tf-acc-pwd")
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBUserAdminDatabase(userName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_database", "admin"),
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "role.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testAccCheckMongoDBUserExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		config := testAccProvider.Meta().(*MongoDatabaseConfiguration)
+		client, err := MongoClientInit(config)
+		if err != nil {
+			return fmt.Errorf("error connecting to database: %s", err)
+		}
+
+		userName, database, err := resourceDatabaseUserParseId(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error parsing ID: %s", err)
+		}
+
+		result, err := getUser(client, userName, database)
+		if err != nil {
+			return fmt.Errorf("error getting user: %s", err)
+		}
+
+		if len(result.Users) == 0 {
+			return fmt.Errorf("user not found: %s", userName)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMongoDBUserDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*MongoDatabaseConfiguration)
+	client, err := MongoClientInit(config)
+	if err != nil {
+		return fmt.Errorf("error connecting to database: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mongodb_db_user" {
+			continue
+		}
+
+		userName, database, err := resourceDatabaseUserParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		db := client.Database(database)
+		result := db.RunCommand(context.Background(), bson.D{
+			{Key: "usersInfo", Value: userName},
+		})
+
+		if result.Err() != nil {
+			// If there's an error getting the user, it might be deleted
+			continue
+		}
+
+		var userResult SingleResultGetUser
+		if err := result.Decode(&userResult); err != nil {
+			return err
+		}
+
+		if len(userResult.Users) > 0 {
+			return fmt.Errorf("user still exists: %s", userName)
+		}
+	}
+
+	return nil
+}
+
+func testAccMongoDBUserBasic(dbName, userName, password string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_user" "test" {
+  auth_database = "%s"
+  name          = "%s"
+  password      = "%s"
+  
+  role {
+    db   = "%s"
+    role = "readWrite"
+  }
+}
+`, dbName, userName, password, dbName)
+}
+
+func testAccMongoDBUserMultipleRoles(dbName, userName, password string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_user" "test" {
+  auth_database = "%s"
+  name          = "%s"
+  password      = "%s"
+  
+  role {
+    db   = "%s"
+    role = "read"
+  }
+  
+  role {
+    db   = "%s"
+    role = "readWrite"
+  }
+}
+`, dbName, userName, password, dbName, dbName)
+}
+
+func testAccMongoDBUserAdminDatabase(userName, password string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_user" "test" {
+  auth_database = "admin"
+  name          = "%s"
+  password      = "%s"
+  
+  role {
+    db   = "admin"
+    role = "userAdminAnyDatabase"
+  }
+}
+`, userName, password)
+}


### PR DESCRIPTION
Eliminate the mongo-express service from the docker-compose configuration and introduce acceptance tests to validate MongoDB role functionalities.