### PR TITLE
feat(iam): add IAM authentication support with MONGODB-AWS mechanism

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,4 +63,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
+	pgregory.net/rapid v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -249,3 +249,5 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
+pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -32,8 +32,9 @@ type ClientConfig struct {
 	Proxy              string
 }
 type DbUser struct {
-	Name     string `json:"name"`
-	Password string `json:"password"`
+	Name          string `json:"name"`
+	Password      string `json:"password"`
+	AuthMechanism string `json:"authMechanism,omitempty"`
 }
 
 type Role struct {
@@ -57,10 +58,11 @@ type Privilege struct {
 }
 type SingleResultGetUser struct {
 	Users []struct {
-		Id    string `json:"_id"`
-		User  string `json:"user"`
-		Db    string `json:"db"`
-		Roles []struct {
+		Id         string   `json:"_id"`
+		User       string   `json:"user"`
+		Db         string   `json:"db"`
+		Mechanisms []string `json:"mechanisms"`
+		Roles      []struct {
 			Role string `json:"role"`
 			Db   string `json:"db"`
 		} `json:"roles"`
@@ -180,6 +182,20 @@ type Resource struct {
 
 func (resource Resource) String() string {
 	return fmt.Sprintf(" { db : %s , collection : %s }", resource.Db, resource.Collection)
+}
+
+func createIAMUser(client *mongo.Client, userName string, roles []Role) error {
+	rolesValue := roles
+	if rolesValue == nil {
+		rolesValue = []Role{}
+	}
+	cmd := bson.D{
+		{Key: "createUser", Value: userName},
+		{Key: "mechanisms", Value: bson.A{"MONGODB-AWS"}},
+		{Key: "roles", Value: rolesValue},
+	}
+	result := client.Database("$external").RunCommand(context.Background(), cmd)
+	return result.Err()
 }
 
 func createUser(client *mongo.Client, user DbUser, roles []Role, database string) error {

--- a/mongodb/helpers.go
+++ b/mongodb/helpers.go
@@ -3,6 +3,7 @@ package mongodb
 import (
 	"encoding/base64"
 	"fmt"
+	"regexp"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -52,4 +53,33 @@ func SetId(data *schema.ResourceData, parts []string) {
 	id := strings.Join(parts, ".")
 	encoded := base64.StdEncoding.EncodeToString([]byte(id))
 	data.SetId(encoded)
+}
+
+// validateAuthMechanism validates the auth_mechanism field.
+// Only "MONGODB-AWS" and "" (empty) are accepted.
+func validateAuthMechanism(v interface{}, path cty.Path) diag.Diagnostics {
+	val, _ := v.(string)
+	if val == "MONGODB-AWS" || val == "" {
+		return nil
+	}
+	return diag.Diagnostics{{
+		Severity:      diag.Error,
+		Summary:       fmt.Sprintf(`auth_mechanism must be "MONGODB-AWS" or empty; got %q`, val),
+		AttributePath: path,
+	}}
+}
+
+var iamARNRegex = regexp.MustCompile(`^arn:aws:iam::\d{12}:(user|role)/[\w+=,.@/-]+$`)
+
+// validateIAMARN validates that a name is a valid IAM ARN when using MONGODB-AWS.
+func validateIAMARN(v interface{}, path cty.Path) diag.Diagnostics {
+	val, _ := v.(string)
+	if iamARNRegex.MatchString(val) {
+		return nil
+	}
+	return diag.Diagnostics{{
+		Severity:      diag.Error,
+		Summary:       `name must be a valid IAM ARN (arn:aws:iam::<account-id>:(user|role)/<name>) when auth_mechanism is "MONGODB-AWS"`,
+		AttributePath: path,
+	}}
 }

--- a/mongodb/helpers_test.go
+++ b/mongodb/helpers_test.go
@@ -1,0 +1,145 @@
+package mongodb
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"pgregory.net/rapid"
+)
+
+// TestValidateAuthMechanism_Valid — "MONGODB-AWS" and "" return no errors.
+func TestValidateAuthMechanism_Valid(t *testing.T) {
+	for _, v := range []string{"MONGODB-AWS", ""} {
+		diags := validateAuthMechanism(v, cty.Path{})
+		if len(diags) != 0 {
+			t.Errorf("expected no diagnostics for %q, got: %v", v, diags)
+		}
+	}
+}
+
+// TestValidateAuthMechanism_Invalid — arbitrary non-MONGODB-AWS strings return errors.
+func TestValidateAuthMechanism_Invalid(t *testing.T) {
+	for _, v := range []string{"SCRAM-SHA-256", "mongodb-aws", "AWS", "plain", "x509"} {
+		diags := validateAuthMechanism(v, cty.Path{})
+		if len(diags) == 0 {
+			t.Errorf("expected error diagnostic for %q, got none", v)
+		}
+	}
+}
+
+// TestValidateIAMARN_Valid — well-formed user and role ARNs return no errors.
+func TestValidateIAMARN_Valid(t *testing.T) {
+	valid := []string{
+		"arn:aws:iam::123456789012:user/alice",
+		"arn:aws:iam::000000000000:role/MyRole",
+		"arn:aws:iam::999999999999:user/path/to/user",
+		"arn:aws:iam::123456789012:role/service-role/MyLambdaRole",
+		"arn:aws:iam::123456789012:user/user+name@example.com",
+	}
+	for _, v := range valid {
+		diags := validateIAMARN(v, cty.Path{})
+		if len(diags) != 0 {
+			t.Errorf("expected no diagnostics for %q, got: %v", v, diags)
+		}
+	}
+}
+
+// TestValidateIAMARN_Invalid — malformed strings return errors.
+func TestValidateIAMARN_Invalid(t *testing.T) {
+	invalid := []string{
+		"",
+		"arn:aws:iam::12345:user/alice",          // account ID too short
+		"arn:aws:iam::123456789012:group/admins", // unsupported type
+		"arn:aws:s3:::my-bucket",                 // wrong service
+		"arn:aws:iam::123456789012:user/",        // empty name
+		"123456789012:user/alice",                // missing arn prefix
+		"arn:aws:iam::123456789012:user",         // missing slash+name
+	}
+	for _, v := range invalid {
+		diags := validateIAMARN(v, cty.Path{})
+		if len(diags) == 0 {
+			t.Errorf("expected error diagnostic for %q, got none", v)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Property-based tests
+// ---------------------------------------------------------------------------
+
+// Feature: documentdb-iam-auth, Property 1: invalid auth_mechanism values are always rejected
+// Validates: Requirements 1.4
+func TestProperty_InvalidAuthMechanismAlwaysRejected(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Generate strings that are neither "MONGODB-AWS" nor empty.
+		val := rapid.StringMatching(`[A-Za-z0-9_\-]{1,50}`).Filter(func(s string) bool {
+			return s != "MONGODB-AWS" && s != ""
+		}).Draw(t, "auth_mechanism")
+
+		diags := validateAuthMechanism(val, cty.Path{})
+		if len(diags) == 0 {
+			t.Fatalf("expected at least one error diagnostic for %q, got none", val)
+		}
+	})
+}
+
+// Feature: documentdb-iam-auth, Property 2: valid IAM ARNs always pass ARN validation
+// Validates: Requirements 8.1, 8.3
+func TestProperty_ValidIAMARNAlwaysPasses(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		accountID := rapid.StringMatching(`\d{12}`).Draw(t, "account_id")
+		iamType := rapid.SampledFrom([]string{"user", "role"}).Draw(t, "iam_type")
+		name := rapid.StringMatching(`[\w][\w+=,.@/-]*`).Draw(t, "name")
+
+		arn := fmt.Sprintf("arn:aws:iam::%s:%s/%s", accountID, iamType, name)
+		diags := validateIAMARN(arn, cty.Path{})
+		if len(diags) != 0 {
+			t.Fatalf("expected no diagnostics for valid ARN %q, got: %v", arn, diags)
+		}
+	})
+}
+
+// Feature: documentdb-iam-auth, Property 3: invalid strings always fail ARN validation
+// Validates: Requirements 8.1, 8.2, 8.4
+func TestProperty_InvalidARNAlwaysFails(t *testing.T) {
+	arnPattern := regexp.MustCompile(`^arn:aws:iam::\d{12}:(user|role)/[\w+=,.@/-]+$`)
+
+	rapid.Check(t, func(t *rapid.T) {
+		val := rapid.String().Filter(func(s string) bool {
+			return !arnPattern.MatchString(s)
+		}).Draw(t, "invalid_arn")
+
+		diags := validateIAMARN(val, cty.Path{})
+		if len(diags) == 0 {
+			t.Fatalf("expected at least one error diagnostic for %q, got none", val)
+		}
+	})
+}
+
+// Feature: documentdb-iam-auth, Property 4: auth_database is always "$external" for IAM users
+// Validates: Requirements 2.2
+func TestProperty_IAMUserDatabaseAlwaysExternal(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// For any arbitrary auth_database value, resolveAuthDatabase with MONGODB-AWS
+		// must always return "$external".
+		currentAuthDB := rapid.String().Draw(t, "auth_database")
+		resolved := resolveAuthDatabase("MONGODB-AWS", currentAuthDB)
+		if resolved != "$external" {
+			t.Fatalf("expected auth_database to be \"$external\" for IAM user, got %q (input: %q)", resolved, currentAuthDB)
+		}
+	})
+}
+
+// Feature: documentdb-iam-auth, Property 5: non-empty password always rejected for IAM users
+// Validates: Requirements 3.1
+func TestProperty_NonEmptyPasswordAlwaysRejected(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		password := rapid.StringN(1, 100, -1).Draw(t, "password")
+		err := validateDBUserDiff("MONGODB-AWS", password)
+		if err == nil {
+			t.Fatalf("expected error for MONGODB-AWS with non-empty password %q, got nil", password)
+		}
+	})
+}

--- a/mongodb/resource_db_user.go
+++ b/mongodb/resource_db_user.go
@@ -7,11 +7,60 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
+
+func customizeDiffDBUser(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	authMechanism := d.Get("auth_mechanism").(string)
+	password := d.Get("password").(string)
+
+	// On update, suppress password diffs for IAM users instead of erroring —
+	// the password field is irrelevant for MONGODB-AWS (Requirement 4.2).
+	if authMechanism == "MONGODB-AWS" && password != "" && d.Id() != "" {
+		if err := d.Clear("password"); err != nil {
+			return err
+		}
+		password = ""
+	}
+
+	if err := validateDBUserDiff(authMechanism, password); err != nil {
+		return err
+	}
+
+	currentAuthDB := d.Get("auth_database").(string)
+	if resolved := resolveAuthDatabase(authMechanism, currentAuthDB); resolved != currentAuthDB {
+		return d.SetNew("auth_database", resolved)
+	}
+	return nil
+}
+
+// resolveAuthDatabase returns the effective auth_database for a user.
+// For IAM users (MONGODB-AWS), it always returns "$external" regardless of the input.
+// For password users, it returns the provided value unchanged.
+func resolveAuthDatabase(authMechanism, currentAuthDB string) string {
+	if authMechanism == "MONGODB-AWS" {
+		return "$external"
+	}
+	return currentAuthDB
+}
+
+// validateDBUserDiff contains the pure cross-field validation logic, extracted for unit testing.
+func validateDBUserDiff(authMechanism, password string) error {
+	if authMechanism == "MONGODB-AWS" {
+		if password != "" {
+			return fmt.Errorf(`password must not be set when auth_mechanism is "MONGODB-AWS"`)
+		}
+		return nil
+	}
+	if password == "" {
+		return fmt.Errorf("password is required when auth_mechanism is not set")
+	}
+	return nil
+}
 
 func resourceDatabaseUser() *schema.Resource {
 	return &schema.Resource{
@@ -22,6 +71,9 @@ func resourceDatabaseUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		CustomizeDiff: customdiff.All(
+			customizeDiffDBUser,
+		),
 		Schema: map[string]*schema.Schema{
 			"auth_database": {
 				Type:     schema.TypeString,
@@ -34,8 +86,13 @@ func resourceDatabaseUser() *schema.Resource {
 			},
 			"password": {
 				Type:      schema.TypeString,
-				Required:  true,
+				Optional:  true,
 				Sensitive: true,
+			},
+			"auth_mechanism": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateAuthMechanism,
 			},
 			"role": {
 				Type:     schema.TypeSet,
@@ -100,36 +157,61 @@ func resourceDatabaseUserUpdate(ctx context.Context, data *schema.ResourceData, 
 
 	var userName = data.Get("name").(string)
 	var database = data.Get("auth_database").(string)
+	var authMechanism = data.Get("auth_mechanism").(string)
 
 	adminDB := client.Database(database)
 
 	// Only update if password or roles have changed
 	if data.HasChange("password") || data.HasChange("role") {
-		var userPassword = data.Get("password").(string)
-		var roleList []Role
-		roles := data.Get("role").(*schema.Set).List()
-		roleMapErr := mapstructure.Decode(roles, &roleList)
-		if roleMapErr != nil {
-			return diag.Errorf("Error decoding map : %s ", roleMapErr)
-		}
-
-		var result *mongo.SingleResult
-		if len(roleList) != 0 {
-			result = adminDB.RunCommand(context.Background(), bson.D{
-				{Key: "updateUser", Value: userName},
-				{Key: "pwd", Value: userPassword},
-				{Key: "roles", Value: roleList},
-			})
+		if authMechanism == "MONGODB-AWS" {
+			// For IAM users: only update roles when they changed; ignore password changes entirely
+			if data.HasChange("role") {
+				var roleList []Role
+				roles := data.Get("role").(*schema.Set).List()
+				roleMapErr := mapstructure.Decode(roles, &roleList)
+				if roleMapErr != nil {
+					return diag.Errorf("Error decoding map : %s ", roleMapErr)
+				}
+				rolesValue := roleList
+				if rolesValue == nil {
+					rolesValue = []Role{}
+				}
+				result := adminDB.RunCommand(context.Background(), bson.D{
+					{Key: "updateUser", Value: userName},
+					{Key: "roles", Value: rolesValue},
+				})
+				if result.Err() != nil {
+					return diag.Errorf("Could not update the user : %s ", result.Err())
+				}
+			}
+			// password-only change for IAM user: no-op
 		} else {
-			result = adminDB.RunCommand(context.Background(), bson.D{
-				{Key: "updateUser", Value: userName},
-				{Key: "pwd", Value: userPassword},
-				{Key: "roles", Value: []bson.M{}},
-			})
-		}
+			var userPassword = data.Get("password").(string)
+			var roleList []Role
+			roles := data.Get("role").(*schema.Set).List()
+			roleMapErr := mapstructure.Decode(roles, &roleList)
+			if roleMapErr != nil {
+				return diag.Errorf("Error decoding map : %s ", roleMapErr)
+			}
 
-		if result.Err() != nil {
-			return diag.Errorf("Could not update the user : %s ", result.Err())
+			var result *mongo.SingleResult
+			if len(roleList) != 0 {
+				result = adminDB.RunCommand(context.Background(), bson.D{
+					{Key: "updateUser", Value: userName},
+					{Key: "pwd", Value: userPassword},
+					{Key: "roles", Value: roleList},
+				})
+			} else {
+				result = adminDB.RunCommand(context.Background(), bson.D{
+					{Key: "updateUser", Value: userName},
+					{Key: "pwd", Value: userPassword},
+					{Key: "roles", Value: []bson.M{}},
+				})
+			}
+
+			if result.Err() != nil {
+				return diag.Errorf("Could not update the user : %s ", result.Err())
+			}
 		}
 	}
 
@@ -181,6 +263,16 @@ func resourceDatabaseUserRead(ctx context.Context, data *schema.ResourceData, i 
 	if dataSetError != nil {
 		return diag.Errorf("error setting password : %s ", dataSetError)
 	}
+	// Detect IAM users from the mechanisms field returned by MongoDB
+	for _, m := range result.Users[0].Mechanisms {
+		if m == "MONGODB-AWS" {
+			dataSetError = data.Set("auth_mechanism", "MONGODB-AWS")
+			if dataSetError != nil {
+				return diag.Errorf("error setting auth_mechanism : %s ", dataSetError)
+			}
+			break
+		}
+	}
 	data.SetId(stateID)
 	return nil
 }
@@ -193,21 +285,31 @@ func resourceDatabaseUserCreate(ctx context.Context, data *schema.ResourceData, 
 	}
 	var database = data.Get("auth_database").(string)
 	var userName = data.Get("name").(string)
-	var userPassword = data.Get("password").(string)
+	var authMechanism = data.Get("auth_mechanism").(string)
 	var roleList []Role
-	var user = DbUser{
-		Name:     userName,
-		Password: userPassword,
-	}
 	roles := data.Get("role").(*schema.Set).List()
 	roleMapErr := mapstructure.Decode(roles, &roleList)
 	if roleMapErr != nil {
 		return diag.Errorf("Error decoding map : %s ", roleMapErr)
 	}
-	err := createUser(client, user, roleList, database)
-	if err != nil {
-		return diag.Errorf("Could not create the user : %s ", err)
+
+	if authMechanism == "MONGODB-AWS" {
+		err := createIAMUser(client, userName, roleList)
+		if err != nil {
+			return diag.Errorf("Could not create the user : %s ", err)
+		}
+	} else {
+		var userPassword = data.Get("password").(string)
+		var user = DbUser{
+			Name:     userName,
+			Password: userPassword,
+		}
+		err := createUser(client, user, roleList, database)
+		if err != nil {
+			return diag.Errorf("Could not create the user : %s ", err)
+		}
 	}
+
 	str := database + "." + userName
 	encoded := base64.StdEncoding.EncodeToString([]byte(str))
 	data.SetId(encoded)

--- a/mongodb/resource_db_user_test.go
+++ b/mongodb/resource_db_user_test.go
@@ -281,3 +281,251 @@ resource "mongodb_db_user" "test" {
 }
 `, userName, password)
 }
+
+// Unit tests for customizeDiffDBUser (via validateDBUserDiff + schema.ResourceDiff).
+// These do not require a running MongoDB instance.
+
+func TestCustomizeDiff_IAMPasswordConflict(t *testing.T) {
+	err := validateDBUserDiff("MONGODB-AWS", "somepassword")
+	if err == nil {
+		t.Fatal("expected error when password is set with MONGODB-AWS, got nil")
+	}
+	expected := `password must not be set when auth_mechanism is "MONGODB-AWS"`
+	if err.Error() != expected {
+		t.Fatalf("unexpected error message: got %q, want %q", err.Error(), expected)
+	}
+}
+
+func TestCustomizeDiff_IAMForcesExternalDatabase(t *testing.T) {
+	// The $external forcing is done via d.SetNew in customizeDiffDBUser.
+	// We verify here that validateDBUserDiff returns no error for MONGODB-AWS + empty password,
+	// which is the prerequisite for the SetNew call to be reached.
+	err := validateDBUserDiff("MONGODB-AWS", "")
+	if err != nil {
+		t.Fatalf("expected no error for MONGODB-AWS with empty password, got: %v", err)
+	}
+
+	// Also verify that non-empty auth_database values don't affect the validation result —
+	// the override to $external is a side-effect handled by customizeDiffDBUser itself.
+	// We test the full function via a resource diff using the schema.
+	resource := resourceDatabaseUser()
+	if resource.CustomizeDiff == nil {
+		t.Fatal("expected CustomizeDiff to be set on resourceDatabaseUser")
+	}
+}
+
+func TestCustomizeDiff_PasswordRequired(t *testing.T) {
+	err := validateDBUserDiff("", "")
+	if err == nil {
+		t.Fatal("expected error when auth_mechanism is absent and password is empty, got nil")
+	}
+	expected := "password is required when auth_mechanism is not set"
+	if err.Error() != expected {
+		t.Fatalf("unexpected error message: got %q, want %q", err.Error(), expected)
+	}
+}
+
+func TestCustomizeDiff_PasswordPresentNoMechanism(t *testing.T) {
+	// Sanity check: normal password-based user should pass validation.
+	err := validateDBUserDiff("", "mysecretpassword")
+	if err != nil {
+		t.Fatalf("expected no error for standard password user, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance tests for IAM (MONGODB-AWS) user support
+// These tests require a running DocumentDB/MongoDB instance.
+// Set env vars per TESTING.md and TF_ACC=1 to run them.
+// ---------------------------------------------------------------------------
+
+// TestAccMongoDBUser_IAMBasic creates an IAM user with a valid ARN, verifies it
+// exists in the $external database, checks auth_mechanism in state, and imports.
+// Requirements: 2.1, 2.2, 2.4, 6.1, 6.2, 6.3
+func TestAccMongoDBUser_IAMBasic(t *testing.T) {
+	// Use a fixed fake ARN — real DocumentDB IAM auth requires a real AWS account,
+	// but the provider logic (createUser with mechanisms=MONGODB-AWS) is what we test.
+	iamARN := "arn:aws:iam::123456789012:user/tf-acc-iam-user"
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBUserIAMBasic(iamARN),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_database", "$external"),
+					resource.TestCheckResourceAttr(resourceName, "name", iamARN),
+					resource.TestCheckResourceAttr(resourceName, "auth_mechanism", "MONGODB-AWS"),
+					resource.TestCheckResourceAttr(resourceName, "role.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+// TestAccMongoDBUser_IAMUpdateRoles creates an IAM user then updates its roles,
+// verifying the new role set is reflected in state.
+// Requirements: 4.1, 4.3
+func TestAccMongoDBUser_IAMUpdateRoles(t *testing.T) {
+	iamARN := "arn:aws:iam::123456789012:role/tf-acc-iam-role"
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBUserIAMBasic(iamARN),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_mechanism", "MONGODB-AWS"),
+					resource.TestCheckResourceAttr(resourceName, "role.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBUserIAMMultipleRoles(iamARN),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_mechanism", "MONGODB-AWS"),
+					resource.TestCheckResourceAttr(resourceName, "role.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMongoDBUser_IAMPasswordIgnored verifies that adding a password field to an
+// existing IAM user config produces no diff (no-op), confirming that password changes
+// are silently ignored for IAM users rather than triggering an update.
+// Requirements: 4.2
+func TestAccMongoDBUser_IAMPasswordIgnored(t *testing.T) {
+	iamARN := "arn:aws:iam::123456789012:user/tf-acc-iam-pwd-test"
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: create the IAM user without a password — should succeed.
+			{
+				Config: testAccMongoDBUserIAMBasic(iamARN),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_mechanism", "MONGODB-AWS"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database", "$external"),
+				),
+			},
+			// Step 2: apply a config with a password field set on the IAM user.
+			// The password diff must be suppressed — no update should occur (no-op).
+			{
+				Config:             testAccMongoDBUserIAMWithPassword(iamARN, "should-be-ignored"),
+				ExpectNonEmptyPlan: false,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_mechanism", "MONGODB-AWS"),
+					resource.TestCheckResourceAttr(resourceName, "auth_database", "$external"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMongoDBUser_BackwardCompat runs a standard password-user config and verifies
+// that the IAM feature addition has not broken existing behavior.
+// Requirements: 7.1, 7.2, 7.3
+func TestAccMongoDBUser_BackwardCompat(t *testing.T) {
+	userName := acctest.RandomWithPrefix("tf-acc-compat")
+	password := acctest.RandomWithPrefix("tf-acc-pwd")
+	dbName := acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBUserBasic(dbName, userName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "auth_database", dbName),
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					// auth_mechanism must NOT be set for password users (Req 7.3)
+					resource.TestCheckNoResourceAttr(resourceName, "auth_mechanism"),
+					resource.TestCheckResourceAttr(resourceName, "role.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Config helpers for IAM acceptance tests
+// ---------------------------------------------------------------------------
+
+func testAccMongoDBUserIAMBasic(iamARN string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_user" "test" {
+  auth_mechanism = "MONGODB-AWS"
+  name           = "%s"
+
+  role {
+    db   = "admin"
+    role = "read"
+  }
+}
+`, iamARN)
+}
+
+func testAccMongoDBUserIAMMultipleRoles(iamARN string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_user" "test" {
+  auth_mechanism = "MONGODB-AWS"
+  name           = "%s"
+
+  role {
+    db   = "admin"
+    role = "read"
+  }
+
+  role {
+    db   = "admin"
+    role = "readWrite"
+  }
+}
+`, iamARN)
+}
+
+func testAccMongoDBUserIAMWithPassword(iamARN, password string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_user" "test" {
+  auth_mechanism = "MONGODB-AWS"
+  name           = "%s"
+  password       = "%s"
+
+  role {
+    db   = "admin"
+    role = "read"
+  }
+}
+`, iamARN, password)
+}


### PR DESCRIPTION
Rebase of #19 (by @MarkelAlvarez) onto the current `main`, which now includes the split build/unit/acceptance CI (#20). Original authorship is preserved.

## What

Adds MONGODB-AWS (IAM) authentication to `mongodb_db_user`:
- New `auth_mechanism` field (`""` or `MONGODB-AWS`) with a validator.
- IAM create path via `createUser` with `mechanisms=["MONGODB-AWS"]` against the `$external` database.
- `CustomizeDiff` cross-field validation (password vs. IAM, `$external` enforcement).
- `password` relaxed from `Required` to `Optional`; requirement re-enforced at plan time for password users.
- Unit, property-based (`pgregory.net/rapid`), and acceptance tests.

## Status — CI currently red, fixes incoming

Running the rebased branch through the new CI surfaced issues to resolve before merge:

**Dependency (blocking build/CI):**
- [ ] Repo is vendored — `go mod vendor` was not run for `pgregory.net/rapid`, so `go test` fails with inconsistent vendoring.
- [ ] `pgregory.net/rapid` is marked `// indirect` but is a direct test dep (fails the tidy gate).

**Review findings:**
- [ ] `auth_database` is `Required`, so IAM configs that omit it fail validation before `CustomizeDiff` can force `$external` — make it `Optional`.
- [ ] `validateIAMARN` is defined + tested but never wired to the `name` field — MONGODB-AWS names aren't actually ARN-validated.
- [ ] Delete uses `strings.Split(id, ".")[1]` instead of `SplitN` — truncates ARN usernames containing `.` (e.g. emails), targeting the wrong principal on destroy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)