### PR TITLE
fix(iam): make IAM auth usable and turn CI green

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ TEST?=$$(go list ./...)
 ACCTEST_PARALLELISM?=20
 
 build:
-	go build -o terraform-provider-airflow
+	go build -o terraform-provider-mongodb
 
 testacc:
 	TF_ACC=1 go test $(TEST) -parallel $(ACCTEST_PARALLELISM) -v $(TESTARGS) -timeout 5m

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	golang.org/x/net v0.49.0
+	pgregory.net/rapid v1.2.0
 )
 
 require (
@@ -63,5 +64,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.9 // indirect
-	pgregory.net/rapid v1.2.0 // indirect
 )

--- a/mongodb/resource_db_user.go
+++ b/mongodb/resource_db_user.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,6 +18,7 @@ import (
 func customizeDiffDBUser(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
 	authMechanism := d.Get("auth_mechanism").(string)
 	password := d.Get("password").(string)
+	name := d.Get("name").(string)
 
 	// On update, suppress password diffs for IAM users instead of erroring —
 	// the password field is irrelevant for MONGODB-AWS (Requirement 4.2).
@@ -31,7 +33,18 @@ func customizeDiffDBUser(_ context.Context, d *schema.ResourceDiff, _ interface{
 		return err
 	}
 
+	// IAM users: name must be a valid ARN (cross-field, so not a ValidateDiagFunc).
+	if authMechanism == "MONGODB-AWS" {
+		if diags := validateIAMARN(name, cty.Path{}); diags.HasError() {
+			return fmt.Errorf("%s", diags[0].Summary)
+		}
+	}
+
 	currentAuthDB := d.Get("auth_database").(string)
+	// IAM users may omit auth_database (forced to "$external"); password users must set it.
+	if authMechanism != "MONGODB-AWS" && currentAuthDB == "" {
+		return fmt.Errorf("auth_database is required when auth_mechanism is not set")
+	}
 	if resolved := resolveAuthDatabase(authMechanism, currentAuthDB); resolved != currentAuthDB {
 		return d.SetNew("auth_database", resolved)
 	}
@@ -77,7 +90,8 @@ func resourceDatabaseUser() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"auth_database": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -122,16 +136,11 @@ func resourceDatabaseUserDelete(ctx context.Context, data *schema.ResourceData, 
 		return diag.Errorf("Error connecting to database : %s ", connectionError)
 	}
 	var stateId = data.State().ID
-	var database = data.Get("auth_database").(string)
-
-	id, errEncoding := base64.StdEncoding.DecodeString(stateId)
-	if errEncoding != nil {
-		return diag.Errorf("ID mismatch %s", errEncoding)
+	// SplitN (via parseId) keeps dotted usernames intact, e.g. IAM ARNs.
+	userName, database, parseErr := resourceDatabaseUserParseId(stateId)
+	if parseErr != nil {
+		return diag.Errorf("%s", parseErr)
 	}
-
-	// StateID is a concatenation of database and username. We only use the username here.
-	splitId := strings.Split(string(id), ".")
-	userName := splitId[1]
 
 	adminDB := client.Database(database)
 

--- a/mongodb/resource_db_user.go
+++ b/mongodb/resource_db_user.go
@@ -101,6 +101,7 @@ func resourceDatabaseUser() *schema.Resource {
 			"password": {
 				Type:      schema.TypeString,
 				Optional:  true,
+				Computed:  true,
 				Sensitive: true,
 			},
 			"auth_mechanism": {
@@ -272,14 +273,18 @@ func resourceDatabaseUserRead(ctx context.Context, data *schema.ResourceData, i 
 	if dataSetError != nil {
 		return diag.Errorf("error setting password : %s ", dataSetError)
 	}
-	// Detect IAM users from the mechanisms field returned by MongoDB
+	// IAM users live in $external; the mechanisms field isn't returned for
+	// external users, so detect by database and fall back to mechanisms.
+	isIAM := database == "$external"
 	for _, m := range result.Users[0].Mechanisms {
 		if m == "MONGODB-AWS" {
-			dataSetError = data.Set("auth_mechanism", "MONGODB-AWS")
-			if dataSetError != nil {
-				return diag.Errorf("error setting auth_mechanism : %s ", dataSetError)
-			}
+			isIAM = true
 			break
+		}
+	}
+	if isIAM {
+		if dataSetError = data.Set("auth_mechanism", "MONGODB-AWS"); dataSetError != nil {
+			return diag.Errorf("error setting auth_mechanism : %s ", dataSetError)
 		}
 	}
 	data.SetId(stateID)


### PR DESCRIPTION
Cleanup follow-up to #19 (IAM / MONGODB-AWS support), which merged to `main` red. Fixes the CI failures and the review findings.

## CI failures fixed
- **Acceptance** — the IAM tests failed with *"The argument \"auth_database\" is required"*. `auth_database` was `Required`, so IAM configs that omit it errored during config validation, before `CustomizeDiff` could force `$external`. Now **`Optional + Computed`**; password users are still required to set it (enforced in `CustomizeDiff`).
- **Tidy gate** — `pgregory.net/rapid` was marked `// indirect` but is a direct test dependency. Now a direct require.

## Review findings fixed
- **`validateIAMARN` was dead code** — defined and unit-tested but never wired in, so a `MONGODB-AWS` user's `name` was never actually ARN-validated. Now invoked from `CustomizeDiff` (it must be conditional on `auth_mechanism`, so it can't be a plain `ValidateDiagFunc` on `name`).
- **Delete truncated dotted ARNs** — used `strings.Split(id, ".")[1]`, which broke on ARN usernames containing `.` (e.g. emails), dropping the wrong principal. Now uses `resourceDatabaseUserParseId` (`SplitN`), consistent with read.

## Also
- Fixed the `Makefile` `build` target that output `terraform-provider-airflow`.

## Verification
- Local: `go build`, `go vet`, `gofmt` (on changed file), `go mod tidy` (idempotent/clean), and unit + property tests all pass.
- Acceptance runs on CI (needs a database) — see the checks on this PR.

> Note: several untouched files have pre-existing `gofmt` drift; left alone here since the linter runs with `only-new-issues: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)