### PR TITLE
feat(db_user): add list resource (terraform query support)

### DIFF
--- a/mongodb/framework.go
+++ b/mongodb/framework.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/list"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -109,6 +110,14 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 
 	mc := &MongoDatabaseConfiguration{Config: &clientConfig, MaxConnLifetime: 10}
 	resp.ResourceData = mc
+	// List resources receive provider data from a separate field.
+	resp.ListResourceData = mc
+}
+
+func (p *frameworkProvider) ListResources(_ context.Context) []func() list.ListResource {
+	return []func() list.ListResource{
+		newDBUserListResource,
+	}
 }
 
 func (p *frameworkProvider) Resources(_ context.Context) []func() resource.Resource {

--- a/mongodb/framework_db_user.go
+++ b/mongodb/framework_db_user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -54,10 +55,19 @@ var (
 	_ resource.ResourceWithImportState      = &dbUserResource{}
 	_ resource.ResourceWithModifyPlan       = &dbUserResource{}
 	_ resource.ResourceWithConfigValidators = &dbUserResource{}
+	_ resource.ResourceWithIdentity         = &dbUserResource{}
 )
 
 func (r *dbUserResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_db_user"
+}
+
+func (r *dbUserResource) IdentitySchema(_ context.Context, _ resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+	resp.IdentitySchema = identityschema.Schema{
+		Attributes: map[string]identityschema.Attribute{
+			"id": identityschema.StringAttribute{RequiredForImport: true},
+		},
+	}
 }
 
 func (r *dbUserResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -252,6 +262,7 @@ func (r *dbUserResource) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError("Error reading user after create", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: state.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -274,6 +285,7 @@ func (r *dbUserResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 	state.Password = prevPassword
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: state.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -329,6 +341,7 @@ func (r *dbUserResource) Update(ctx context.Context, req resource.UpdateRequest,
 		resp.Diagnostics.AddError("Error reading user after update", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: state.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/mongodb/framework_db_user_list.go
+++ b/mongodb/framework_db_user_list.go
@@ -1,0 +1,82 @@
+package mongodb
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+var (
+	_ list.ListResource              = &dbUserListResource{}
+	_ list.ListResourceWithConfigure = &dbUserListResource{}
+)
+
+func newDBUserListResource() list.ListResource { return &dbUserListResource{} }
+
+type dbUserListResource struct {
+	config *MongoDatabaseConfiguration
+}
+
+type dbUserIdentityModel struct {
+	ID types.String `tfsdk:"id"`
+}
+
+func (r *dbUserListResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_db_user"
+}
+
+func (r *dbUserListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+	resp.Schema = listschema.Schema{
+		MarkdownDescription: "Lists all MongoDB database users. Use with `terraform query` (Terraform 1.14 and later).",
+	}
+}
+
+func (r *dbUserListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	config, ok := req.ProviderData.(*MongoDatabaseConfiguration)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data", fmt.Sprintf("expected *MongoDatabaseConfiguration, got %T", req.ProviderData))
+		return
+	}
+	r.config = config
+}
+
+func (r *dbUserListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
+	client, err := MongoClientInit(r.config)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError("Error connecting to database", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	cmd := bson.D{{Key: "usersInfo", Value: bson.D{{Key: "forAllDBs", Value: true}}}}
+	var decoded SingleResultGetUser
+	if err := client.Database("admin").RunCommand(ctx, cmd).Decode(&decoded); err != nil {
+		var diags diag.Diagnostics
+		diags.AddError("Failed to list users", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, u := range decoded.Users {
+			id := base64.StdEncoding.EncodeToString([]byte(u.Db + "." + u.User))
+			result := req.NewListResult(ctx)
+			result.DisplayName = u.User
+			result.Diagnostics.Append(result.Identity.Set(ctx, dbUserIdentityModel{ID: types.StringValue(id)})...)
+			if !push(result) {
+				return
+			}
+		}
+	}
+}

--- a/mongodb/framework_test.go
+++ b/mongodb/framework_test.go
@@ -38,6 +38,32 @@ func TestMuxProviderSchema(t *testing.T) {
 	}
 }
 
+// TestMuxListResources verifies the mux server actually serves the framework
+// list resource(s) — i.e. that terraform-plugin-mux propagates list resources.
+func TestMuxListResources(t *testing.T) {
+	ctx := context.Background()
+	factory, err := MuxServerFactory(ctx)
+	if err != nil {
+		t.Fatalf("MuxServerFactory: %s", err)
+	}
+	resp, err := factory().GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema: %s", err)
+	}
+	for _, d := range resp.Diagnostics {
+		if d.Severity == tfprotov6.DiagnosticSeverityError {
+			t.Errorf("provider schema diagnostic: %s — %s", d.Summary, d.Detail)
+		}
+	}
+	if _, ok := resp.ListResourceSchemas["mongodb_db_user"]; !ok {
+		got := make([]string, 0, len(resp.ListResourceSchemas))
+		for k := range resp.ListResourceSchemas {
+			got = append(got, k)
+		}
+		t.Errorf("mongodb_db_user not served as a list resource through the mux; list schemas present: %v", got)
+	}
+}
+
 // TestResourceStateShapeUnchanged is the state-compatibility guard for the
 // SDKv2 -> framework migration. For each migrated resource it asserts the
 // framework schema has the same attribute names and types as the retained


### PR DESCRIPTION
Adds a `mongodb_db_user` **list resource** so `terraform query` (Terraform 1.14+) can enumerate existing database users. Now that the provider is on terraform-plugin-framework, this is possible.

## Confirmed: the mux serves list resources
The provider is muxed (SDKv2 + framework). I verified `tf6muxserver v0.23.1` propagates framework list resources — `TestMuxListResources` builds the muxed server and asserts `mongodb_db_user` appears in `ListResourceSchemas` (no database needed).

## What's here
- **`framework_db_user_list.go`** — the list resource; enumerates users via `usersInfo: {forAllDBs: true}`.
- **`framework.go`** — registers `ListResources()` and sets `resp.ListResourceData`. That second part matters: without it the list resource is never configured and **panics** on the first call (the exact bug I just fixed in the airflow provider).
- **`framework_db_user.go`** — adds an `IdentitySchema` (`id`) and sets the resource identity in Create/Read/Update, so list results carry a valid identity.

## Known gap (follow-up)
A runtime **query acceptance test** requires `terraform-plugin-testing` (query mode), which **cannot coexist** with the SDKv2 `helper/resource` the other tests use — both register a `sweep` flag → `panic: flag redefined`. Migrating the test suite from SDKv2 `helper/resource` to `terraform-plugin-testing` is a clean, behavior-preserving follow-up that unblocks it (and is appropriate now the provider is framework-based).

CI here validates: build/vet/tidy, unit + the mux/list/state-shape guards, and that the `IdentitySchema` addition doesn't regress the existing `db_user` acceptance tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)