### PR TITLE
feat: add list resources for db_role, db_collection, db_index

### DIFF
--- a/mongodb/framework.go
+++ b/mongodb/framework.go
@@ -117,6 +117,9 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 func (p *frameworkProvider) ListResources(_ context.Context) []func() list.ListResource {
 	return []func() list.ListResource{
 		newDBUserListResource,
+		newDBRoleListResource,
+		newDBCollectionListResource,
+		newDBIndexListResource,
 	}
 }
 

--- a/mongodb/framework_db_collection.go
+++ b/mongodb/framework_db_collection.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -34,10 +35,19 @@ var (
 	_ resource.Resource                = &dbCollectionResource{}
 	_ resource.ResourceWithConfigure   = &dbCollectionResource{}
 	_ resource.ResourceWithImportState = &dbCollectionResource{}
+	_ resource.ResourceWithIdentity    = &dbCollectionResource{}
 )
 
 func (r *dbCollectionResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_db_collection"
+}
+
+func (r *dbCollectionResource) IdentitySchema(_ context.Context, _ resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+	resp.IdentitySchema = identityschema.Schema{
+		Attributes: map[string]identityschema.Attribute{
+			"id": identityschema.StringAttribute{RequiredForImport: true},
+		},
+	}
 }
 
 func (r *dbCollectionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -116,6 +126,7 @@ func (r *dbCollectionResource) Create(ctx context.Context, req resource.CreateRe
 		resp.Diagnostics.AddError("Error reading collection after create", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: state.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -143,6 +154,7 @@ func (r *dbCollectionResource) Read(ctx context.Context, req resource.ReadReques
 	} else {
 		state.DeletionProtection = prevDeletionProtection
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: state.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -176,6 +188,7 @@ func (r *dbCollectionResource) Update(ctx context.Context, req resource.UpdateRe
 		resp.Diagnostics.AddError("Error reading collection after update", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: state.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 

--- a/mongodb/framework_db_collection_list.go
+++ b/mongodb/framework_db_collection_list.go
@@ -1,0 +1,83 @@
+package mongodb
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+var (
+	_ list.ListResource              = &dbCollectionListResource{}
+	_ list.ListResourceWithConfigure = &dbCollectionListResource{}
+)
+
+func newDBCollectionListResource() list.ListResource { return &dbCollectionListResource{} }
+
+type dbCollectionListResource struct {
+	config *MongoDatabaseConfiguration
+}
+
+func (r *dbCollectionListResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_db_collection"
+}
+
+func (r *dbCollectionListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+	resp.Schema = listschema.Schema{
+		MarkdownDescription: "Lists all MongoDB collections across databases. Use with `terraform query` (Terraform 1.14 and later).",
+	}
+}
+
+func (r *dbCollectionListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	config, ok := req.ProviderData.(*MongoDatabaseConfiguration)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data", fmt.Sprintf("expected *MongoDatabaseConfiguration, got %T", req.ProviderData))
+		return
+	}
+	r.config = config
+}
+
+func (r *dbCollectionListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
+	client, err := MongoClientInit(r.config)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError("Error connecting to database", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	dbNames, err := client.ListDatabaseNames(ctx, bson.D{})
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError("Failed to list databases", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, dbName := range dbNames {
+			collNames, err := client.Database(dbName).ListCollectionNames(ctx, bson.D{})
+			if err != nil {
+				continue // skip databases we can't list collections for
+			}
+			for _, coll := range collNames {
+				id := base64.StdEncoding.EncodeToString([]byte(dbName + "." + coll))
+				result := req.NewListResult(ctx)
+				result.DisplayName = coll
+				result.Diagnostics.Append(result.Identity.Set(ctx, dbUserIdentityModel{ID: types.StringValue(id)})...)
+				if !push(result) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/mongodb/framework_db_index.go
+++ b/mongodb/framework_db_index.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -55,10 +56,19 @@ var (
 	_ resource.Resource                = &dbIndexResource{}
 	_ resource.ResourceWithConfigure   = &dbIndexResource{}
 	_ resource.ResourceWithImportState = &dbIndexResource{}
+	_ resource.ResourceWithIdentity    = &dbIndexResource{}
 )
 
 func (r *dbIndexResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_db_index"
+}
+
+func (r *dbIndexResource) IdentitySchema(_ context.Context, _ resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+	resp.IdentitySchema = identityschema.Schema{
+		Attributes: map[string]identityschema.Attribute{
+			"id": identityschema.StringAttribute{RequiredForImport: true},
+		},
+	}
 }
 
 func (r *dbIndexResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -158,6 +168,7 @@ func (r *dbIndexResource) Create(ctx context.Context, req resource.CreateRequest
 		resp.Diagnostics.AddError("Error reading index after create", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: plan.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -178,6 +189,7 @@ func (r *dbIndexResource) Read(ctx context.Context, req resource.ReadRequest, re
 		resp.Diagnostics.AddError("Error reading index", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: state.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -219,6 +231,7 @@ func (r *dbIndexResource) Update(ctx context.Context, req resource.UpdateRequest
 		resp.Diagnostics.AddError("Error reading index after update", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: plan.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 

--- a/mongodb/framework_db_index_list.go
+++ b/mongodb/framework_db_index_list.go
@@ -1,0 +1,95 @@
+package mongodb
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+var (
+	_ list.ListResource              = &dbIndexListResource{}
+	_ list.ListResourceWithConfigure = &dbIndexListResource{}
+)
+
+func newDBIndexListResource() list.ListResource { return &dbIndexListResource{} }
+
+type dbIndexListResource struct {
+	config *MongoDatabaseConfiguration
+}
+
+func (r *dbIndexListResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_db_index"
+}
+
+func (r *dbIndexListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+	resp.Schema = listschema.Schema{
+		MarkdownDescription: "Lists all MongoDB indexes across databases and collections. Use with `terraform query` (Terraform 1.14 and later).",
+	}
+}
+
+func (r *dbIndexListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	config, ok := req.ProviderData.(*MongoDatabaseConfiguration)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data", fmt.Sprintf("expected *MongoDatabaseConfiguration, got %T", req.ProviderData))
+		return
+	}
+	r.config = config
+}
+
+func (r *dbIndexListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
+	client, err := MongoClientInit(r.config)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError("Error connecting to database", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	dbNames, err := client.ListDatabaseNames(ctx, bson.D{})
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError("Failed to list databases", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, dbName := range dbNames {
+			collNames, err := client.Database(dbName).ListCollectionNames(ctx, bson.D{})
+			if err != nil {
+				continue
+			}
+			for _, coll := range collNames {
+				cursor, err := client.Database(dbName).Collection(coll).Indexes().List(ctx)
+				if err != nil {
+					continue
+				}
+				var idxs []struct {
+					Name string `bson:"name"`
+				}
+				if err := cursor.All(ctx, &idxs); err != nil {
+					continue
+				}
+				for _, idx := range idxs {
+					id := base64.StdEncoding.EncodeToString([]byte(dbName + "." + coll + "." + idx.Name))
+					result := req.NewListResult(ctx)
+					result.DisplayName = idx.Name
+					result.Diagnostics.Append(result.Identity.Set(ctx, dbUserIdentityModel{ID: types.StringValue(id)})...)
+					if !push(result) {
+						return
+					}
+				}
+			}
+		}
+	}
+}

--- a/mongodb/framework_db_role.go
+++ b/mongodb/framework_db_role.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -59,10 +60,19 @@ var (
 	_ resource.Resource                = &dbRoleResource{}
 	_ resource.ResourceWithConfigure   = &dbRoleResource{}
 	_ resource.ResourceWithImportState = &dbRoleResource{}
+	_ resource.ResourceWithIdentity    = &dbRoleResource{}
 )
 
 func (r *dbRoleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_db_role"
+}
+
+func (r *dbRoleResource) IdentitySchema(_ context.Context, _ resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+	resp.IdentitySchema = identityschema.Schema{
+		Attributes: map[string]identityschema.Attribute{
+			"id": identityschema.StringAttribute{RequiredForImport: true},
+		},
+	}
 }
 
 func (r *dbRoleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -152,6 +162,7 @@ func (r *dbRoleResource) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError("Error reading role after create", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: state.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -172,6 +183,7 @@ func (r *dbRoleResource) Read(ctx context.Context, req resource.ReadRequest, res
 		resp.Diagnostics.AddError("Error reading role", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: state.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
@@ -221,6 +233,7 @@ func (r *dbRoleResource) Update(ctx context.Context, req resource.UpdateRequest,
 		resp.Diagnostics.AddError("Error reading role after update", err.Error())
 		return
 	}
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, dbUserIdentityModel{ID: newState.ID})...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
 }
 

--- a/mongodb/framework_db_role_list.go
+++ b/mongodb/framework_db_role_list.go
@@ -1,0 +1,86 @@
+package mongodb
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+var (
+	_ list.ListResource              = &dbRoleListResource{}
+	_ list.ListResourceWithConfigure = &dbRoleListResource{}
+)
+
+func newDBRoleListResource() list.ListResource { return &dbRoleListResource{} }
+
+type dbRoleListResource struct {
+	config *MongoDatabaseConfiguration
+}
+
+func (r *dbRoleListResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_db_role"
+}
+
+func (r *dbRoleListResource) ListResourceConfigSchema(_ context.Context, _ list.ListResourceSchemaRequest, resp *list.ListResourceSchemaResponse) {
+	resp.Schema = listschema.Schema{
+		MarkdownDescription: "Lists all custom MongoDB roles across databases. Use with `terraform query` (Terraform 1.14 and later).",
+	}
+}
+
+func (r *dbRoleListResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	config, ok := req.ProviderData.(*MongoDatabaseConfiguration)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data", fmt.Sprintf("expected *MongoDatabaseConfiguration, got %T", req.ProviderData))
+		return
+	}
+	r.config = config
+}
+
+func (r *dbRoleListResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
+	client, err := MongoClientInit(r.config)
+	if err != nil {
+		var diags diag.Diagnostics
+		diags.AddError("Error connecting to database", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	// rolesInfo has no forAllDBs option, so enumerate databases and query each.
+	var dbs struct {
+		Databases []struct{ Name string }
+	}
+	if err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "listDatabases", Value: 1}}).Decode(&dbs); err != nil {
+		var diags diag.Diagnostics
+		diags.AddError("Failed to list databases", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for _, db := range dbs.Databases {
+			var roles SingleResultGetRole
+			if err := client.Database(db.Name).RunCommand(ctx, bson.D{{Key: "rolesInfo", Value: 1}}).Decode(&roles); err != nil {
+				continue // skip databases we can't read roles for
+			}
+			for _, role := range roles.Roles {
+				id := base64.StdEncoding.EncodeToString([]byte(role.Db + "." + role.Role))
+				result := req.NewListResult(ctx)
+				result.DisplayName = role.Role
+				result.Diagnostics.Append(result.Identity.Set(ctx, dbUserIdentityModel{ID: types.StringValue(id)})...)
+				if !push(result) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/mongodb/framework_db_user_list_test.go
+++ b/mongodb/framework_db_user_list_test.go
@@ -50,6 +50,146 @@ list "mongodb_db_user" "test" {
 	})
 }
 
+// TestAccMongoDBRole_list creates a custom role, runs a query against the
+// mongodb_db_role list resource, and asserts the role appears in the results.
+func TestAccMongoDBRole_list(t *testing.T) {
+	roleName := acctest.RandomWithPrefix("tf-acc-role-list")
+	wantID := base64.StdEncoding.EncodeToString([]byte("admin." + roleName))
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBRoleListConfig(roleName),
+			},
+			{
+				Query: true,
+				Config: `
+provider "mongodb" {}
+
+list "mongodb_db_role" "test" {
+  provider = mongodb
+}
+`,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("mongodb_db_role.test", map[string]knownvalue.Check{
+						"id": knownvalue.StringExact(wantID),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func testAccMongoDBRoleListConfig(roleName string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_role" "test" {
+  database = "admin"
+  name     = %[1]q
+
+  privilege {
+    db         = "admin"
+    collection = ""
+    actions    = ["find"]
+  }
+}
+`, roleName)
+}
+
+// TestAccMongoDBCollection_list creates a collection, queries the
+// mongodb_db_collection list resource, and asserts it appears.
+func TestAccMongoDBCollection_list(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("tfacclistdb")
+	collName := acctest.RandomWithPrefix("tfacclistcoll")
+	wantID := base64.StdEncoding.EncodeToString([]byte(dbName + "." + collName))
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "mongodb_db_collection" "test" {
+  db                  = %[1]q
+  name                = %[2]q
+  deletion_protection = false
+}
+`, dbName, collName),
+			},
+			{
+				Query: true,
+				Config: `
+provider "mongodb" {}
+
+list "mongodb_db_collection" "test" {
+  provider = mongodb
+}
+`,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("mongodb_db_collection.test", map[string]knownvalue.Check{
+						"id": knownvalue.StringExact(wantID),
+					}),
+				},
+			},
+		},
+	})
+}
+
+// TestAccMongoDBIndex_list creates an index, queries the mongodb_db_index list
+// resource, and asserts it appears.
+func TestAccMongoDBIndex_list(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("tfacclistdb")
+	collName := acctest.RandomWithPrefix("tfacclistcoll")
+	idxName := "tfacc_list_idx"
+	wantID := base64.StdEncoding.EncodeToString([]byte(dbName + "." + collName + "." + idxName))
+
+	resource.Test(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "mongodb_db_index" "test" {
+  db         = %[1]q
+  collection = %[2]q
+  name       = %[3]q
+
+  keys {
+    field = "myfield"
+    value = "1"
+  }
+}
+`, dbName, collName, idxName),
+			},
+			{
+				Query: true,
+				Config: `
+provider "mongodb" {}
+
+list "mongodb_db_index" "test" {
+  provider = mongodb
+}
+`,
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("mongodb_db_index.test", map[string]knownvalue.Check{
+						"id": knownvalue.StringExact(wantID),
+					}),
+				},
+			},
+		},
+	})
+}
+
 func testAccMongoDBUserListConfig(userName, password string) string {
 	return fmt.Sprintf(`
 resource "mongodb_db_user" "test" {

--- a/mongodb/framework_test.go
+++ b/mongodb/framework_test.go
@@ -55,12 +55,14 @@ func TestMuxListResources(t *testing.T) {
 			t.Errorf("provider schema diagnostic: %s — %s", d.Summary, d.Detail)
 		}
 	}
-	if _, ok := resp.ListResourceSchemas["mongodb_db_user"]; !ok {
-		got := make([]string, 0, len(resp.ListResourceSchemas))
-		for k := range resp.ListResourceSchemas {
-			got = append(got, k)
+	for _, typ := range []string{"mongodb_db_user", "mongodb_db_role", "mongodb_db_collection", "mongodb_db_index"} {
+		if _, ok := resp.ListResourceSchemas[typ]; !ok {
+			got := make([]string, 0, len(resp.ListResourceSchemas))
+			for k := range resp.ListResourceSchemas {
+				got = append(got, k)
+			}
+			t.Errorf("%s not served as a list resource through the mux; list schemas present: %v", typ, got)
 		}
-		t.Errorf("mongodb_db_user not served as a list resource through the mux; list schemas present: %v", got)
 	}
 }
 


### PR DESCRIPTION
Brings the role/collection/index list resources to `main` (the #30 content — it merged into the intermediate stacked branch, not main, and #29's squash made a direct chore→main merge conflict, so this replays it cleanly).

List resources for `db_role` (`listDatabases`+`rolesInfo`), `db_collection` (`ListCollectionNames`), `db_index` (`Indexes().List` per collection), each with an `IdentitySchema` and a `terraform query` acceptance test. Previously green as #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)