### PR TITLE
docs: document IAM auth, write-only password, and list resources (v3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 3.0.0
+
+BREAKING CHANGES:
+
+* The provider now serves **Terraform Plugin Protocol 6** and requires **Terraform 1.0 or later** (previously protocol 5 / Terraform 0.12+). It was re-architected from `terraform-plugin-sdk/v2` to `terraform-plugin-framework`, served through `terraform-plugin-mux`. The migration is behavior-preserving and existing state upgrades cleanly (verified against 2.0.4).
+* `mongodb_db_user`: `password` is no longer `Required` — it is now `Optional` (a password is still required for standard users unless `password_wo` is used). `auth_database` is now `Optional` (defaults to `$external` for `MONGODB-AWS` users).
+
+FEATURES:
+
+* `mongodb_db_user`: IAM authentication for Amazon DocumentDB via `auth_mechanism = "MONGODB-AWS"` (users are created in `$external`; `name` must be an AWS IAM ARN).
+* `mongodb_db_user`: write-only password via `password_wo` + `password_wo_version` — the password is never stored in Terraform state (requires Terraform 1.11+).
+* `mongodb_db_index`: `hidden` indexes (toggleable via `collMod`) and `partial_filter_expression` for partial indexes.
+* **List resources** for `mongodb_db_user`, `mongodb_db_role`, `mongodb_db_collection`, and `mongodb_db_index` — enumerate existing objects with `terraform query` (requires Terraform 1.14+).
+
+NOTES:
+
+* All four resources now expose a resource identity (`id`).

--- a/docs/list-resources/db_collection.md
+++ b/docs/list-resources/db_collection.md
@@ -1,0 +1,21 @@
+# mongodb_db_collection (List Resource)
+
+Lists all MongoDB collections across databases. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing collections.
+
+## Example Usage
+
+```hcl
+list "mongodb_db_collection" "all" {
+  provider = mongodb
+}
+```
+
+Then run:
+
+```sh
+terraform query
+```
+
+## Schema
+
+This list resource takes no configuration arguments — it returns every `mongodb_db_collection`. Each returned resource uses the [`mongodb_db_collection`](../resources/database_collection.md) schema; its identity is the base64-encoded `id` (`db.collectionName`).

--- a/docs/list-resources/db_index.md
+++ b/docs/list-resources/db_index.md
@@ -1,0 +1,21 @@
+# mongodb_db_index (List Resource)
+
+Lists all MongoDB indexes across databases and collections. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing indexes.
+
+## Example Usage
+
+```hcl
+list "mongodb_db_index" "all" {
+  provider = mongodb
+}
+```
+
+Then run:
+
+```sh
+terraform query
+```
+
+## Schema
+
+This list resource takes no configuration arguments — it returns every `mongodb_db_index`. Each returned resource uses the [`mongodb_db_index`](../resources/database_index.md) schema; its identity is the base64-encoded `id` (`db.collection.indexName`).

--- a/docs/list-resources/db_role.md
+++ b/docs/list-resources/db_role.md
@@ -1,0 +1,21 @@
+# mongodb_db_role (List Resource)
+
+Lists all custom MongoDB roles across databases. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing roles.
+
+## Example Usage
+
+```hcl
+list "mongodb_db_role" "all" {
+  provider = mongodb
+}
+```
+
+Then run:
+
+```sh
+terraform query
+```
+
+## Schema
+
+This list resource takes no configuration arguments — it returns every custom `mongodb_db_role`. Each returned resource uses the [`mongodb_db_role`](../resources/database_role.md) schema; its identity is the base64-encoded `id` (`database.roleName`).

--- a/docs/list-resources/db_user.md
+++ b/docs/list-resources/db_user.md
@@ -1,0 +1,21 @@
+# mongodb_db_user (List Resource)
+
+Lists all MongoDB database users. Use with `terraform query` (Terraform 1.14 and later) to enumerate existing users across all databases.
+
+## Example Usage
+
+```hcl
+list "mongodb_db_user" "all" {
+  provider = mongodb
+}
+```
+
+Then run:
+
+```sh
+terraform query
+```
+
+## Schema
+
+This list resource takes no configuration arguments — it returns every `mongodb_db_user`. Each returned resource uses the [`mongodb_db_user`](../resources/database_user.md) schema; its identity is the base64-encoded `id` (`auth_database.username`).

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -5,7 +5,7 @@ Provides a Database User resource.
 
 Each user has a set of roles that provide access to the databases.
 
-> **IMPORTANT:** All arguments including the password will be stored in the raw state as plain-text. [Read more about sensitive data in state.](https://developer.hashicorp.com/terraform/state/sensitive-data)
+> **IMPORTANT:** The `password` argument is stored in the raw state as plain-text. [Read more about sensitive data in state.](https://developer.hashicorp.com/terraform/state/sensitive-data) To keep the password out of state entirely, use the write-only `password_wo` argument (Terraform 1.11+).
 
 ## Example Usages
 
@@ -49,11 +49,46 @@ resource "mongodb_db_user" "user_with_custom_role" {
 }
 ```
 
+#### Create a user with a write-only password (Terraform 1.11+)
+
+`password_wo` is never stored in Terraform state. Bump `password_wo_version` to rotate it.
+
+```hcl
+resource "mongodb_db_user" "user_wo" {
+  auth_database       = "my_database"
+  name                = "example"
+  password_wo         = var.password
+  password_wo_version = "1"
+  role {
+    role = "readWrite"
+    db   = "my_database"
+  }
+}
+```
+
+#### Create an IAM (MONGODB-AWS) user for Amazon DocumentDB
+
+For `MONGODB-AWS`, `name` must be an AWS IAM ARN, no password is set, and the user lives in the `$external` database.
+
+```hcl
+resource "mongodb_db_user" "iam" {
+  auth_mechanism = "MONGODB-AWS"
+  name           = "arn:aws:iam::123456789012:role/my-app-role"
+  role {
+    role = "readWrite"
+    db   = "my_database"
+  }
+}
+```
+
 ## Argument Reference
 
-* `auth_database` (Required, string) – Database against which Mongo authenticates the user. A user must provide both a username and authentication database to log into MongoDB.
-* `name` (Required, string) – Username for authenticating to MongoDB.
-* `password` (Required, string, Sensitive) – User's initial password. A value is required to create the database user. Passwords may show up in Terraform related logs and will be stored in the Terraform state file as plain-text. See [Sensitive Data in State](https://developer.hashicorp.com/terraform/state/sensitive-data).
+* `auth_database` (Optional, string) – Database against which Mongo authenticates the user. Defaults to `$external` for `MONGODB-AWS` users; required for password users.
+* `name` (Required, string) – Username for authenticating to MongoDB. For `MONGODB-AWS` this must be a valid AWS IAM ARN (`arn:aws:iam::<account-id>:(user|role)/<name>`).
+* `password` (Optional, string, Sensitive) – User's password, stored in state as plain-text. Mutually exclusive with `password_wo`. Required for password users unless `password_wo` is set. See [Sensitive Data in State](https://developer.hashicorp.com/terraform/state/sensitive-data).
+* `password_wo` (Optional, string, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) – User's password, supplied via config and **never stored in state**. Requires Terraform 1.11+. Mutually exclusive with `password`; requires `password_wo_version`.
+* `password_wo_version` (Optional, string) – Change this to rotate the write-only `password_wo` (write-only values aren't tracked in state, so this is the update trigger).
+* `auth_mechanism` (Optional, string) – Authentication mechanism. Either `MONGODB-AWS` (Amazon DocumentDB IAM authentication) or empty (standard SCRAM password auth). When `MONGODB-AWS`, `password`/`password_wo` must not be set.
 * `role` (Optional, block) – List of user’s roles and the databases/collections on which the roles apply. See [Role Block](#role-block) below for more details.
 
 ### Role Block
@@ -71,7 +106,8 @@ This resource exports the following attributes:
 
 * `id` – The base64-encoded ID of the user in the format `auth_database.username`.
 * `name` – The username.
-* `auth_database` – The authentication database.
+* `auth_database` – The authentication database (`$external` for `MONGODB-AWS` users).
+* `auth_mechanism` – Set to `MONGODB-AWS` for IAM users; unset for password users.
 
 
 ## Import


### PR DESCRIPTION
Fills the documentation gaps before the v3.0.0 release (the docs are hand-maintained — no tfplugindocs — so nothing auto-updated).

## What
- **`docs/resources/database_user.md`** — documents `auth_mechanism` (MONGODB-AWS / DocumentDB IAM), `password_wo` + `password_wo_version` (write-only), notes `password`/`auth_database` are now optional, and adds IAM + write-only examples.
- **`docs/list-resources/{db_user,db_role,db_collection,db_index}.md`** — new list-resource pages with `terraform query` usage.
- **`CHANGELOG.md`** — 3.0.0 entry (breaking protocol 5→6 / framework migration; IAM auth; write-only password; hidden/partial indexes; list resources).

## Note
Existing resource docs are named `database_*.md` while the resource types are `mongodb_db_*`; I used the type shortname (`db_*.md`) for the new list-resource docs to match the registry convention. The resource-doc naming mismatch is pre-existing — worth a separate cleanup, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)