### PR TITLE
test: cover db_collection deletion_protection and db_role update

### DIFF
--- a/mongodb/resource_db_collection_test.go
+++ b/mongodb/resource_db_collection_test.go
@@ -3,6 +3,7 @@ package mongodb
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -15,11 +16,11 @@ func TestAccMongoDBCollection_Basic(t *testing.T) {
 	var collectionName = acctest.RandomWithPrefix("tf-acc-test")
 	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
 	resourceName := "mongodb_db_collection.test"
-	
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBCollectionDestroy,
+		CheckDestroy:             testAccCheckMongoDBCollectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBCollectionBasic(databaseName, collectionName),
@@ -32,9 +33,9 @@ func TestAccMongoDBCollection_Basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
@@ -45,11 +46,11 @@ func TestAccMongoDBCollection_WithChangeStreamImages(t *testing.T) {
 	var collectionName = acctest.RandomWithPrefix("tf-acc-test")
 	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
 	resourceName := "mongodb_db_collection.test"
-	
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBCollectionDestroy,
+		CheckDestroy:             testAccCheckMongoDBCollectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBCollectionWithChangeStreamImages(databaseName, collectionName),
@@ -62,9 +63,9 @@ func TestAccMongoDBCollection_WithChangeStreamImages(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
@@ -75,11 +76,11 @@ func TestAccMongoDBCollection_Update(t *testing.T) {
 	var collectionName = acctest.RandomWithPrefix("tf-acc-test")
 	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
 	resourceName := "mongodb_db_collection.test"
-	
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBCollectionDestroy,
+		CheckDestroy:             testAccCheckMongoDBCollectionDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBCollectionBasic(databaseName, collectionName),
@@ -166,6 +167,52 @@ func testAccCheckMongoDBCollectionDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+// TestAccMongoDBCollection_deletionProtection verifies that deletion_protection
+// blocks destroy while enabled, and that clearing it allows cleanup.
+func TestAccMongoDBCollection_deletionProtection(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("tf-acc-db")
+	collName := acctest.RandomWithPrefix("tf-acc-coll")
+	resourceName := "mongodb_db_collection.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMongoDBCollectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBCollectionProtected(dbName, collName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBCollectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "true"),
+				),
+			},
+			{
+				// Removing the collection while protected must fail the destroy.
+				Config:      "// deletion_protection blocks destroy\n",
+				ExpectError: regexp.MustCompile(`deletion protection`),
+			},
+			{
+				// Clearing protection allows the collection to be destroyed (teardown).
+				Config: testAccMongoDBCollectionProtected(dbName, collName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBCollectionExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "deletion_protection", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBCollectionProtected(dbName, collectionName string, protected bool) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_collection" "test" {
+  db                  = %[1]q
+  name                = %[2]q
+  deletion_protection = %[3]t
+}
+`, dbName, collectionName, protected)
 }
 
 func testAccMongoDBCollectionBasic(dbName, collectionName string) string {

--- a/mongodb/resource_db_role_test.go
+++ b/mongodb/resource_db_role_test.go
@@ -17,9 +17,9 @@ func TestAccMongoDBRole_Basic(t *testing.T) {
 	resourceName := "mongodb_db_role.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBRoleDestroy,
+		CheckDestroy:             testAccCheckMongoDBRoleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBRoleBasic(databaseName, roleName),
@@ -45,9 +45,9 @@ func TestAccMongoDBRole_WithInheritedRoles(t *testing.T) {
 	resourceName := "mongodb_db_role.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBRoleDestroy,
+		CheckDestroy:             testAccCheckMongoDBRoleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBRoleWithInheritedRoles(databaseName, roleName),
@@ -74,9 +74,9 @@ func TestAccMongoDBRole_MultiplePrivileges(t *testing.T) {
 	resourceName := "mongodb_db_role.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBRoleDestroy,
+		CheckDestroy:             testAccCheckMongoDBRoleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBRoleMultiplePrivileges(databaseName, roleName),
@@ -91,6 +91,38 @@ func TestAccMongoDBRole_MultiplePrivileges(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccMongoDBRole_Update exercises the role update path (which drops and
+// recreates the role): it changes the privilege set and verifies the new set.
+func TestAccMongoDBRole_Update(t *testing.T) {
+	roleName := acctest.RandomWithPrefix("tf-acc-role")
+	dbName := acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMongoDBRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBRoleBasic(dbName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "privilege.#", "1"),
+				),
+			},
+			{
+				Config: testAccMongoDBRoleMultiplePrivileges(dbName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", roleName),
+					resource.TestCheckResourceAttr(resourceName, "privilege.#", "2"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
Adds acceptance tests for existing behavior that had no coverage:

- **`TestAccMongoDBCollection_deletionProtection`** — asserts destroy is refused while `deletion_protection = true` (via `ExpectError`), then clears it so cleanup succeeds.
- **`TestAccMongoDBRole_Update`** — exercises the role update path (drop + recreate), changing the privilege set and verifying the new one.

No new resource surface — pure coverage. First of the gap-closing work (#4); `authentication_restrictions` (#3) and provider `auth_mechanism`/OIDC to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)