### PR TITLE
feat(db_user): add authentication_restriction

### DIFF
--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -184,7 +184,7 @@ func (resource Resource) String() string {
 	return fmt.Sprintf(" { db : %s , collection : %s }", resource.Db, resource.Collection)
 }
 
-func createIAMUser(client *mongo.Client, userName string, roles []Role) error {
+func createIAMUser(client *mongo.Client, userName string, roles []Role, authRestrictions bson.A) error {
 	rolesValue := roles
 	if rolesValue == nil {
 		rolesValue = []Role{}
@@ -194,21 +194,27 @@ func createIAMUser(client *mongo.Client, userName string, roles []Role) error {
 		{Key: "mechanisms", Value: bson.A{"MONGODB-AWS"}},
 		{Key: "roles", Value: rolesValue},
 	}
+	if len(authRestrictions) > 0 {
+		cmd = append(cmd, bson.E{Key: "authenticationRestrictions", Value: authRestrictions})
+	}
 	result := client.Database("$external").RunCommand(context.Background(), cmd)
 	return result.Err()
 }
 
-func createUser(client *mongo.Client, user DbUser, roles []Role, database string) error {
-	var result *mongo.SingleResult
-	if len(roles) != 0 {
-		result = client.Database(database).RunCommand(context.Background(), bson.D{{Key: "createUser", Value: user.Name},
-			{Key: "pwd", Value: user.Password}, {Key: "roles", Value: roles}})
-	} else {
-		result = client.Database(database).RunCommand(context.Background(), bson.D{{Key: "createUser", Value: user.Name},
-			{Key: "pwd", Value: user.Password}, {Key: "roles", Value: []bson.M{}}})
+func createUser(client *mongo.Client, user DbUser, roles []Role, database string, authRestrictions bson.A) error {
+	var rolesValue interface{} = roles
+	if len(roles) == 0 {
+		rolesValue = []bson.M{}
 	}
-
-	if result.Err() != nil {
+	cmd := bson.D{
+		{Key: "createUser", Value: user.Name},
+		{Key: "pwd", Value: user.Password},
+		{Key: "roles", Value: rolesValue},
+	}
+	if len(authRestrictions) > 0 {
+		cmd = append(cmd, bson.E{Key: "authenticationRestrictions", Value: authRestrictions})
+	}
+	if result := client.Database(database).RunCommand(context.Background(), cmd); result.Err() != nil {
 		return result.Err()
 	}
 	return nil

--- a/mongodb/framework_db_user.go
+++ b/mongodb/framework_db_user.go
@@ -36,6 +36,12 @@ type dbUserResourceModel struct {
 	PasswordWOVersion types.String `tfsdk:"password_wo_version"`
 	AuthMechanism     types.String `tfsdk:"auth_mechanism"`
 	Roles             types.Set    `tfsdk:"role"`
+	AuthRestrictions  types.Set    `tfsdk:"authentication_restriction"`
+}
+
+type authRestrictionModel struct {
+	ClientSource  types.List `tfsdk:"client_source"`
+	ServerAddress types.List `tfsdk:"server_address"`
 }
 
 type dbUserRoleModel struct {
@@ -114,6 +120,14 @@ func (r *dbUserResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 					Attributes: map[string]schema.Attribute{
 						"db":   schema.StringAttribute{Optional: true},
 						"role": schema.StringAttribute{Required: true},
+					},
+				},
+			},
+			"authentication_restriction": schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"client_source":  schema.ListAttribute{Optional: true, ElementType: types.StringType},
+						"server_address": schema.ListAttribute{Optional: true, ElementType: types.StringType},
 					},
 				},
 			},
@@ -232,12 +246,14 @@ func (r *dbUserResource) Create(ctx context.Context, req resource.CreateRequest,
 	authMechanism := plan.AuthMechanism.ValueString()
 	roleList, diags := rolesFromSet(ctx, plan.Roles)
 	resp.Diagnostics.Append(diags...)
+	authRestrictions, arDiags := authRestrictionsFromSet(ctx, plan.AuthRestrictions)
+	resp.Diagnostics.Append(arDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	if authMechanism == "MONGODB-AWS" {
-		if err := createIAMUser(client, userName, roleList); err != nil {
+		if err := createIAMUser(client, userName, roleList, authRestrictions); err != nil {
 			resp.Diagnostics.AddError("Could not create the user", err.Error())
 			return
 		}
@@ -248,7 +264,7 @@ func (r *dbUserResource) Create(ctx context.Context, req resource.CreateRequest,
 			return
 		}
 		user := DbUser{Name: userName, Password: pw}
-		if err := createUser(client, user, roleList, database); err != nil {
+		if err := createUser(client, user, roleList, database, authRestrictions); err != nil {
 			resp.Diagnostics.AddError("Could not create the user", err.Error())
 			return
 		}
@@ -258,6 +274,7 @@ func (r *dbUserResource) Create(ctx context.Context, req resource.CreateRequest,
 	var state dbUserResourceModel
 	state.Password = knownOrEmpty(plan.Password)
 	state.PasswordWOVersion = plan.PasswordWOVersion
+	state.AuthRestrictions = plan.AuthRestrictions
 	if err := r.readUserInto(client, id, &state); err != nil {
 		resp.Diagnostics.AddError("Error reading user after create", err.Error())
 		return
@@ -307,6 +324,8 @@ func (r *dbUserResource) Update(ctx context.Context, req resource.UpdateRequest,
 	authMechanism := plan.AuthMechanism.ValueString()
 	roleList, diags := rolesFromSet(ctx, plan.Roles)
 	resp.Diagnostics.Append(diags...)
+	authRestrictions, arDiags := authRestrictionsFromSet(ctx, plan.AuthRestrictions)
+	resp.Diagnostics.Append(arDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -314,19 +333,23 @@ func (r *dbUserResource) Update(ctx context.Context, req resource.UpdateRequest,
 	if rolesValue == nil {
 		rolesValue = []Role{}
 	}
+	// Always send authenticationRestrictions on update (empty clears them).
+	if authRestrictions == nil {
+		authRestrictions = bson.A{}
+	}
 
 	adminDB := client.Database(database)
 	var cmd bson.D
 	if authMechanism == "MONGODB-AWS" {
 		// IAM users: update roles only; password is ignored.
-		cmd = bson.D{{Key: "updateUser", Value: userName}, {Key: "roles", Value: rolesValue}}
+		cmd = bson.D{{Key: "updateUser", Value: userName}, {Key: "roles", Value: rolesValue}, {Key: "authenticationRestrictions", Value: authRestrictions}}
 	} else {
 		pw, pwDiags := effectivePassword(ctx, req.Config, plan)
 		resp.Diagnostics.Append(pwDiags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		cmd = bson.D{{Key: "updateUser", Value: userName}, {Key: "pwd", Value: pw}, {Key: "roles", Value: rolesValue}}
+		cmd = bson.D{{Key: "updateUser", Value: userName}, {Key: "pwd", Value: pw}, {Key: "roles", Value: rolesValue}, {Key: "authenticationRestrictions", Value: authRestrictions}}
 	}
 	if result := adminDB.RunCommand(ctx, cmd); result.Err() != nil {
 		resp.Diagnostics.AddError("Could not update the user", result.Err().Error())
@@ -337,6 +360,7 @@ func (r *dbUserResource) Update(ctx context.Context, req resource.UpdateRequest,
 	var state dbUserResourceModel
 	state.Password = knownOrEmpty(plan.Password)
 	state.PasswordWOVersion = plan.PasswordWOVersion
+	state.AuthRestrictions = plan.AuthRestrictions
 	if err := r.readUserInto(client, id, &state); err != nil {
 		resp.Diagnostics.AddError("Error reading user after update", err.Error())
 		return
@@ -441,6 +465,40 @@ func rolesFromSet(ctx context.Context, set types.Set) ([]Role, diag.Diagnostics)
 		roles = append(roles, Role{Role: m.Role.ValueString(), Db: m.Db.ValueString()})
 	}
 	return roles, diags
+}
+
+// authRestrictionsFromSet builds the MongoDB authenticationRestrictions array
+// (each entry a {clientSource, serverAddress} document) from the configured set.
+func authRestrictionsFromSet(ctx context.Context, set types.Set) (bson.A, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if set.IsNull() || set.IsUnknown() {
+		return nil, diags
+	}
+	var models []authRestrictionModel
+	diags.Append(set.ElementsAs(ctx, &models, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	arr := bson.A{}
+	for _, m := range models {
+		doc := bson.D{}
+		if !m.ClientSource.IsNull() && !m.ClientSource.IsUnknown() {
+			var cs []string
+			diags.Append(m.ClientSource.ElementsAs(ctx, &cs, false)...)
+			if len(cs) > 0 {
+				doc = append(doc, bson.E{Key: "clientSource", Value: cs})
+			}
+		}
+		if !m.ServerAddress.IsNull() && !m.ServerAddress.IsUnknown() {
+			var sa []string
+			diags.Append(m.ServerAddress.ElementsAs(ctx, &sa, false)...)
+			if len(sa) > 0 {
+				doc = append(doc, bson.E{Key: "serverAddress", Value: sa})
+			}
+		}
+		arr = append(arr, doc)
+	}
+	return arr, diags
 }
 
 func knownOrEmpty(v types.String) types.String {

--- a/mongodb/framework_test.go
+++ b/mongodb/framework_test.go
@@ -82,7 +82,7 @@ func TestResourceStateShapeUnchanged(t *testing.T) {
 		// (additive, not a state-compat concern) and excluded from the check.
 		newAttrs map[string]bool
 	}{
-		{"mongodb_db_user", resourceDatabaseUser(), newDBUserResource(), map[string]bool{"password_wo": true, "password_wo_version": true}},
+		{"mongodb_db_user", resourceDatabaseUser(), newDBUserResource(), map[string]bool{"password_wo": true, "password_wo_version": true, "authentication_restriction": true}},
 		{"mongodb_db_role", resourceDatabaseRole(), newDBRoleResource(), nil},
 		{"mongodb_db_collection", resourceDatabaseCollection(), newDBCollectionResource(), nil},
 		{"mongodb_db_index", resourceDatabaseIndex(), newDBIndexResource(), nil},

--- a/mongodb/resource_db_user.go
+++ b/mongodb/resource_db_user.go
@@ -308,7 +308,7 @@ func resourceDatabaseUserCreate(ctx context.Context, data *schema.ResourceData, 
 	}
 
 	if authMechanism == "MONGODB-AWS" {
-		err := createIAMUser(client, userName, roleList)
+		err := createIAMUser(client, userName, roleList, nil)
 		if err != nil {
 			return diag.Errorf("Could not create the user : %s ", err)
 		}
@@ -318,7 +318,7 @@ func resourceDatabaseUserCreate(ctx context.Context, data *schema.ResourceData, 
 			Name:     userName,
 			Password: userPassword,
 		}
-		err := createUser(client, user, roleList, database)
+		err := createUser(client, user, roleList, database, nil)
 		if err != nil {
 			return diag.Errorf("Could not create the user : %s ", err)
 		}

--- a/mongodb/resource_db_user_test.go
+++ b/mongodb/resource_db_user_test.go
@@ -356,6 +356,52 @@ resource "mongodb_db_user" "test" {
 `, dbName, userName, password, version, dbName)
 }
 
+// TestAccMongoDBUser_authenticationRestrictions creates a user with an
+// authentication restriction and verifies it applies with a stable (no-diff)
+// plan afterward.
+func TestAccMongoDBUser_authenticationRestrictions(t *testing.T) {
+	userName := acctest.RandomWithPrefix("tf-acc-authr")
+	password := acctest.RandomWithPrefix("tf-acc-pwd")
+	dbName := acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBUserAuthRestrictions(dbName, userName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_restriction.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_restriction.0.client_source.0", "127.0.0.1/32"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMongoDBUserAuthRestrictions(dbName, userName, password string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_user" "test" {
+  auth_database = %[1]q
+  name          = %[2]q
+  password      = %[3]q
+
+  role {
+    db   = %[1]q
+    role = "readWrite"
+  }
+
+  authentication_restriction {
+    client_source = ["127.0.0.1/32"]
+  }
+}
+`, dbName, userName, password)
+}
+
 func testAccMongoDBUserBasic(dbName, userName, password string) string {
 	return fmt.Sprintf(`
 resource "mongodb_db_user" "test" {


### PR DESCRIPTION
Adds `authentication_restriction` blocks to `mongodb_db_user` (`client_source` / `server_address`), mapping to MongoDB `createUser`/`updateUser` `authenticationRestrictions`. Available in Community MongoDB (3.6+), so it's covered by a real acceptance test.

- Set on create and update; an empty set on update clears them.
- The configured value is preserved in state (not read back) to avoid round-trip format mismatches — same pattern the provider uses for `password`/`deletion_protection`.
- `TestAccMongoDBUser_authenticationRestrictions` verifies apply + a stable (no-diff) plan.

First of the #3 work; `db_role` `authentication_restriction` follows once this pattern is confirmed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)