### PR TITLE
feat(db_role): add authentication_restriction

### DIFF
--- a/docs/resources/database_role.md
+++ b/docs/resources/database_role.md
@@ -75,6 +75,14 @@ Each `inherited_role` block supports the following:
   -> **NOTE:** This value should be `admin` for all roles except `read` and `readWrite`.
 * `role` (Required, string) – Name of the inherited role. This can be another custom role or a [built-in role](https://www.mongodb.com/docs/manual/reference/built-in-roles/).
 
+### Nested Block: `authentication_restriction`
+Maps to MongoDB's role [`authenticationRestrictions`](https://www.mongodb.com/docs/manual/reference/method/db.createRole/#authentication-restrictions). Available in Community MongoDB (3.6+). May be repeated; a connection is allowed if it satisfies any one restriction block.
+
+* `client_source` (Optional, list of string) – IP addresses or CIDR ranges from which a user granted this role is allowed to connect.
+* `server_address` (Optional, list of string) – IP addresses or CIDR ranges of the MongoDB instance addresses a user granted this role is allowed to connect to.
+
+  -> **NOTE:** The configured value is preserved in state as written; the provider does not read the restrictions back from the server.
+
 ## Attributes Reference
 
 This resource exports the following attributes:

--- a/docs/resources/database_user.md
+++ b/docs/resources/database_user.md
@@ -90,6 +90,16 @@ resource "mongodb_db_user" "iam" {
 * `password_wo_version` (Optional, string) – Change this to rotate the write-only `password_wo` (write-only values aren't tracked in state, so this is the update trigger).
 * `auth_mechanism` (Optional, string) – Authentication mechanism. Either `MONGODB-AWS` (Amazon DocumentDB IAM authentication) or empty (standard SCRAM password auth). When `MONGODB-AWS`, `password`/`password_wo` must not be set.
 * `role` (Optional, block) – List of user’s roles and the databases/collections on which the roles apply. See [Role Block](#role-block) below for more details.
+* `authentication_restriction` (Optional, block) – Restricts the IP addresses/CIDR ranges from which the user may connect and to which server addresses. See [Authentication Restriction Block](#authentication-restriction-block) below.
+
+### Authentication Restriction Block
+
+Maps to MongoDB's user [`authenticationRestrictions`](https://www.mongodb.com/docs/manual/reference/method/db.createUser/#authentication-restrictions). Available in Community MongoDB (3.6+). May be repeated; a connection is allowed if it satisfies any one restriction block.
+
+* `client_source` (Optional, list of string) – IP addresses or CIDR ranges from which the user is allowed to connect.
+* `server_address` (Optional, list of string) – IP addresses or CIDR ranges of the MongoDB instance addresses the user is allowed to connect to.
+
+> **NOTE:** The configured value is preserved in state as written; the provider does not read the restrictions back from the server.
 
 ### Role Block
 

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -247,9 +247,8 @@ func getRole(client *mongo.Client, roleName string, database string) (SingleResu
 	return decodedResult, nil
 }
 
-func createRole(client *mongo.Client, role string, roles []Role, privilege []PrivilegeDto, database string) error {
+func createRole(client *mongo.Client, role string, roles []Role, privilege []PrivilegeDto, database string, authRestrictions bson.A) error {
 	var privileges []Privilege
-	var result *mongo.SingleResult
 	for _, element := range privilege {
 		var prv Privilege
 		prv.Resource = Resource{
@@ -259,21 +258,25 @@ func createRole(client *mongo.Client, role string, roles []Role, privilege []Pri
 		prv.Actions = element.Actions
 		privileges = append(privileges, prv)
 	}
-	if len(roles) != 0 && len(privileges) != 0 {
-		result = client.Database(database).RunCommand(context.Background(), bson.D{{Key: "createRole", Value: role},
-			{Key: "privileges", Value: privileges}, {Key: "roles", Value: roles}})
-	} else if len(roles) == 0 && len(privileges) != 0 {
-		result = client.Database(database).RunCommand(context.Background(), bson.D{{Key: "createRole", Value: role},
-			{Key: "privileges", Value: privileges}, {Key: "roles", Value: []bson.M{}}})
-	} else if len(roles) != 0 && len(privileges) == 0 {
-		result = client.Database(database).RunCommand(context.Background(), bson.D{{Key: "createRole", Value: role},
-			{Key: "privileges", Value: []bson.M{}}, {Key: "roles", Value: roles}})
-	} else {
-		result = client.Database(database).RunCommand(context.Background(), bson.D{{Key: "createRole", Value: role},
-			{Key: "privileges", Value: []bson.M{}}, {Key: "roles", Value: []bson.M{}}})
+
+	var privilegesValue interface{} = privileges
+	if len(privileges) == 0 {
+		privilegesValue = []bson.M{}
+	}
+	var rolesValue interface{} = roles
+	if len(roles) == 0 {
+		rolesValue = []bson.M{}
+	}
+	cmd := bson.D{
+		{Key: "createRole", Value: role},
+		{Key: "privileges", Value: privilegesValue},
+		{Key: "roles", Value: rolesValue},
+	}
+	if len(authRestrictions) > 0 {
+		cmd = append(cmd, bson.E{Key: "authenticationRestrictions", Value: authRestrictions})
 	}
 
-	if result.Err() != nil {
+	if result := client.Database(database).RunCommand(context.Background(), cmd); result.Err() != nil {
 		return result.Err()
 	}
 	return nil

--- a/mongodb/framework_db_role.go
+++ b/mongodb/framework_db_role.go
@@ -32,11 +32,12 @@ var dbRoleInheritedObjectType = types.ObjectType{AttrTypes: map[string]attr.Type
 }}
 
 type dbRoleResourceModel struct {
-	ID             types.String `tfsdk:"id"`
-	Database       types.String `tfsdk:"database"`
-	Name           types.String `tfsdk:"name"`
-	Privileges     types.Set    `tfsdk:"privilege"`
-	InheritedRoles types.Set    `tfsdk:"inherited_role"`
+	ID               types.String `tfsdk:"id"`
+	Database         types.String `tfsdk:"database"`
+	Name             types.String `tfsdk:"name"`
+	Privileges       types.Set    `tfsdk:"privilege"`
+	InheritedRoles   types.Set    `tfsdk:"inherited_role"`
+	AuthRestrictions types.Set    `tfsdk:"authentication_restriction"`
 }
 
 type dbRolePrivilegeModel struct {
@@ -112,6 +113,14 @@ func (r *dbRoleResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 					},
 				},
 			},
+			"authentication_restriction": schema.SetNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"client_source":  schema.ListAttribute{Optional: true, ElementType: types.StringType},
+						"server_address": schema.ListAttribute{Optional: true, ElementType: types.StringType},
+					},
+				},
+			},
 		},
 	}
 }
@@ -147,17 +156,20 @@ func (r *dbRoleResource) Create(ctx context.Context, req resource.CreateRequest,
 	resp.Diagnostics.Append(diags...)
 	privileges, diags := privilegesFromSet(ctx, plan.Privileges)
 	resp.Diagnostics.Append(diags...)
+	authRestrictions, arDiags := authRestrictionsFromSet(ctx, plan.AuthRestrictions)
+	resp.Diagnostics.Append(arDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := createRole(client, roleName, roleList, privileges, database); err != nil {
+	if err := createRole(client, roleName, roleList, privileges, database, authRestrictions); err != nil {
 		resp.Diagnostics.AddError("Could not create the role", err.Error())
 		return
 	}
 
 	id := base64.StdEncoding.EncodeToString([]byte(database + "." + roleName))
 	var state dbRoleResourceModel
+	state.AuthRestrictions = plan.AuthRestrictions
 	if err := r.readRoleInto(client, id, &state); err != nil {
 		resp.Diagnostics.AddError("Error reading role after create", err.Error())
 		return
@@ -218,17 +230,20 @@ func (r *dbRoleResource) Update(ctx context.Context, req resource.UpdateRequest,
 	resp.Diagnostics.Append(diags...)
 	privileges, diags := privilegesFromSet(ctx, plan.Privileges)
 	resp.Diagnostics.Append(diags...)
+	authRestrictions, arDiags := authRestrictionsFromSet(ctx, plan.AuthRestrictions)
+	resp.Diagnostics.Append(arDiags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if err := createRole(client, roleName, roleList, privileges, database); err != nil {
+	if err := createRole(client, roleName, roleList, privileges, database, authRestrictions); err != nil {
 		resp.Diagnostics.AddError("Could not update the role", err.Error())
 		return
 	}
 
 	id := base64.StdEncoding.EncodeToString([]byte(database + "." + roleName))
 	var newState dbRoleResourceModel
+	newState.AuthRestrictions = plan.AuthRestrictions
 	if err := r.readRoleInto(client, id, &newState); err != nil {
 		resp.Diagnostics.AddError("Error reading role after update", err.Error())
 		return

--- a/mongodb/framework_test.go
+++ b/mongodb/framework_test.go
@@ -83,7 +83,7 @@ func TestResourceStateShapeUnchanged(t *testing.T) {
 		newAttrs map[string]bool
 	}{
 		{"mongodb_db_user", resourceDatabaseUser(), newDBUserResource(), map[string]bool{"password_wo": true, "password_wo_version": true, "authentication_restriction": true}},
-		{"mongodb_db_role", resourceDatabaseRole(), newDBRoleResource(), nil},
+		{"mongodb_db_role", resourceDatabaseRole(), newDBRoleResource(), map[string]bool{"authentication_restriction": true}},
 		{"mongodb_db_collection", resourceDatabaseCollection(), newDBCollectionResource(), nil},
 		{"mongodb_db_index", resourceDatabaseIndex(), newDBIndexResource(), nil},
 	}

--- a/mongodb/resource_db_role.go
+++ b/mongodb/resource_db_role.go
@@ -102,7 +102,7 @@ func resourceDatabaseRoleCreate(ctx context.Context, data *schema.ResourceData, 
 		return diag.Errorf("Error decoding map : %s ", privMapErr)
 	}
 
-	err := createRole(client, role, roleList, privileges, database)
+	err := createRole(client, role, roleList, privileges, database, nil)
 
 	if err != nil {
 		return diag.Errorf("Could not create the role : %s ", err)
@@ -172,7 +172,7 @@ func resourceDatabaseRoleUpdate(ctx context.Context, data *schema.ResourceData, 
 		return diag.Errorf("Error decoding map : %s ", privMapErr)
 	}
 
-	err2 := createRole(client, role, roleList, privileges, database)
+	err2 := createRole(client, role, roleList, privileges, database, nil)
 
 	if err2 != nil {
 		return diag.Errorf("Could not create the role  :  %s ", err)

--- a/mongodb/resource_db_role_test.go
+++ b/mongodb/resource_db_role_test.go
@@ -128,6 +128,31 @@ func TestAccMongoDBRole_Update(t *testing.T) {
 	})
 }
 
+// TestAccMongoDBRole_authenticationRestrictions creates a role with a
+// client_source authentication restriction and verifies it applies with a
+// stable (no-diff) plan.
+func TestAccMongoDBRole_authenticationRestrictions(t *testing.T) {
+	roleName := acctest.RandomWithPrefix("tf-acc-role")
+	dbName := acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMongoDBRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBRoleAuthRestrictions(dbName, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "authentication_restriction.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_restriction.0.client_source.0", "127.0.0.1/32"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckMongoDBRoleExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -214,6 +239,25 @@ resource "mongodb_db_role" "test" {
     db         = "%s"
     collection = "test_collection"
     actions    = ["find", "insert", "update"]
+  }
+}
+`, dbName, roleName, dbName)
+}
+
+func testAccMongoDBRoleAuthRestrictions(dbName, roleName string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_role" "test" {
+  database = "%s"
+  name     = "%s"
+
+  privilege {
+    db         = "%s"
+    collection = "test_collection"
+    actions    = ["find"]
+  }
+
+  authentication_restriction {
+    client_source = ["127.0.0.1/32"]
   }
 }
 `, dbName, roleName, dbName)


### PR DESCRIPTION
Adds `authentication_restriction` blocks to `mongodb_db_role` (`client_source` / `server_address`), mapping to MongoDB `createRole` `authenticationRestrictions` — the role-side counterpart to #35 (`mongodb_db_user`). Available in Community MongoDB (3.6+), so it's covered by a real acceptance test.

- Set on create and update (the role is dropped and recreated on update, matching the existing update path).
- The configured value is preserved in state (not read back), same pattern as `db_user` and `password`/`deletion_protection`.
- `TestAccMongoDBRole_authenticationRestrictions` verifies apply + a stable (no-diff) plan.
- Refactors `createRole` to build one command document (like `createUser`) instead of the prior four-way `if`/`else` branch.
- Documents the block for **both** `db_role` and `db_user` — the docs were missing for `db_user` (added in #35 without doc coverage).

This completes the `authentication_restriction` (#3) work across user + role. Next: provider-level `auth_mechanism` / OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)