### PR TITLE
feat(provider): add auth_mechanism / auth_mechanism_properties

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -106,4 +106,20 @@ arguments](https://www.terraform.io/docs/configuration/providers.html) (e.g.
 * `retrywrites   ` - (Optional) `default = true `Retryable writes allow MongoDB drivers to automatically retry certain write operations a single time if they encounter network errors, or if they cannot find a healthy primary in the replica sets or sharded cluster.
 * `direct   ` - (Optional) `default = false ` determine if a direct connection is needed..
 * `proxy   ` - (Optional) `default = "" ` determine if connecting via a SOCKS5 proxy is needed, it can also be sourced from the `ALL_PROXY` or `all_proxy` environment variable.
+* `auth_mechanism` - (Optional) The SASL authentication mechanism the provider uses for its own connection, e.g. `SCRAM-SHA-256`, `MONGODB-X509`, `MONGODB-AWS`, or `MONGODB-OIDC`. When empty the driver negotiates SCRAM. Can also be sourced from the `MONGO_AUTH_MECHANISM` environment variable. Mechanisms other than SCRAM authenticate against `$external`, so set `auth_database = "$external"` for `MONGODB-X509`/`MONGODB-AWS`/`MONGODB-OIDC`.
+* `auth_mechanism_properties` - (Optional) Map of additional properties for the selected `auth_mechanism`. For `MONGODB-OIDC` these are the OIDC properties such as `ENVIRONMENT` (e.g. `gcp`, `azure`) and `TOKEN_RESOURCE`; for `MONGODB-AWS`, `AWS_SESSION_TOKEN`.
+
+### Connecting with MONGODB-OIDC
+
+```hcl
+provider "mongodb" {
+  host          = "mongo.example.internal"
+  auth_database = "$external"
+  auth_mechanism = "MONGODB-OIDC"
+  auth_mechanism_properties = {
+    ENVIRONMENT    = "gcp"
+    TOKEN_RESOURCE = "https://mongo.example.internal"
+  }
+}
+```
 

--- a/mongodb/config.go
+++ b/mongodb/config.go
@@ -17,19 +17,21 @@ import (
 )
 
 type ClientConfig struct {
-	ConnectionString   string
-	Host               string
-	Port               string
-	Username           string
-	Password           string
-	DB                 string
-	Tls                bool
-	InsecureSkipVerify bool
-	ReplicaSet         string
-	RetryWrites        bool
-	Certificate        string
-	Direct             bool
-	Proxy              string
+	ConnectionString        string
+	Host                    string
+	Port                    string
+	Username                string
+	Password                string
+	DB                      string
+	Tls                     bool
+	InsecureSkipVerify      bool
+	ReplicaSet              string
+	RetryWrites             bool
+	Certificate             string
+	Direct                  bool
+	Proxy                   string
+	AuthMechanism           string
+	AuthMechanismProperties map[string]string
 }
 type DbUser struct {
 	Name          string `json:"name"`
@@ -133,10 +135,8 @@ func (c *ClientConfig) MongoClient() (*mongo.Client, error) {
 	}
 
 	opts := options.Client().ApplyURI(uri).SetDialer(dialer)
-	if len(c.Username) > 0 && len(c.Password) > 0 {
-		opts.SetAuth(options.Credential{
-			AuthSource: c.DB, Username: c.Username, Password: c.Password,
-		})
+	if cred, ok := buildCredential(c); ok {
+		opts.SetAuth(cred)
 	}
 
 	if c.Certificate != "" || verify {
@@ -150,6 +150,36 @@ func (c *ClientConfig) MongoClient() (*mongo.Client, error) {
 	// In MongoDB driver v2, mongo.Connect() no longer accepts a context parameter
 	client, err := mongo.Connect(opts)
 	return client, err
+}
+
+// buildCredential assembles the driver auth credential from the client config.
+// It returns ok=false when there is nothing to authenticate with (no mechanism
+// and no username/password pair), leaving the connection unauthenticated.
+//
+// A credential is produced when an explicit auth_mechanism is set OR a
+// username/password pair is present. This lets mechanisms that don't use a
+// password — MONGODB-X509, MONGODB-AWS (IAM roles), MONGODB-OIDC — authenticate
+// with no password. External mechanisms authenticate against the database named
+// by auth_database, which must be "$external" for X.509/AWS/OIDC.
+func buildCredential(c *ClientConfig) (options.Credential, bool) {
+	hasUserPass := len(c.Username) > 0 && len(c.Password) > 0
+	if c.AuthMechanism == "" && !hasUserPass {
+		return options.Credential{}, false
+	}
+
+	cred := options.Credential{
+		AuthSource:    c.DB,
+		AuthMechanism: c.AuthMechanism,
+		Username:      c.Username,
+	}
+	if len(c.AuthMechanismProperties) > 0 {
+		cred.AuthMechanismProperties = c.AuthMechanismProperties
+	}
+	if c.Password != "" {
+		cred.Password = c.Password
+		cred.PasswordSet = true
+	}
+	return cred, true
 }
 
 func getTLSConfig(ca []byte, verify bool) (*tls.Config, error) {

--- a/mongodb/config_test.go
+++ b/mongodb/config_test.go
@@ -1,0 +1,113 @@
+package mongodb
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestBuildCredential covers the auth credential assembled from the provider
+// config across the supported mechanisms. It exercises the construction logic
+// only (no live connection), which is the coverage available for mechanisms
+// that CI cannot exercise against community mongo (X.509/AWS/OIDC).
+func TestBuildCredential(t *testing.T) {
+	cases := []struct {
+		name        string
+		cfg         ClientConfig
+		wantOK      bool
+		wantMech    string
+		wantUser    string
+		wantPass    string
+		wantPassSet bool
+		wantSource  string
+		wantProps   map[string]string
+	}{
+		{
+			name:   "no mechanism and no credentials leaves connection unauthenticated",
+			cfg:    ClientConfig{DB: "admin"},
+			wantOK: false,
+		},
+		{
+			name:        "username and password with no mechanism (SCRAM negotiated)",
+			cfg:         ClientConfig{DB: "admin", Username: "root", Password: "secret"},
+			wantOK:      true,
+			wantUser:    "root",
+			wantPass:    "secret",
+			wantPassSet: true,
+			wantSource:  "admin",
+		},
+		{
+			name:        "explicit SCRAM-SHA-256 mechanism",
+			cfg:         ClientConfig{DB: "admin", Username: "root", Password: "secret", AuthMechanism: "SCRAM-SHA-256"},
+			wantOK:      true,
+			wantMech:    "SCRAM-SHA-256",
+			wantUser:    "root",
+			wantPass:    "secret",
+			wantPassSet: true,
+			wantSource:  "admin",
+		},
+		{
+			name:       "MONGODB-X509 authenticates with no password",
+			cfg:        ClientConfig{DB: "$external", AuthMechanism: "MONGODB-X509"},
+			wantOK:     true,
+			wantMech:   "MONGODB-X509",
+			wantSource: "$external",
+		},
+		{
+			name: "MONGODB-OIDC with mechanism properties and no password",
+			cfg: ClientConfig{
+				DB:            "$external",
+				AuthMechanism: "MONGODB-OIDC",
+				AuthMechanismProperties: map[string]string{
+					"ENVIRONMENT":    "gcp",
+					"TOKEN_RESOURCE": "https://mongodb.example",
+				},
+			},
+			wantOK:     true,
+			wantMech:   "MONGODB-OIDC",
+			wantSource: "$external",
+			wantProps: map[string]string{
+				"ENVIRONMENT":    "gcp",
+				"TOKEN_RESOURCE": "https://mongodb.example",
+			},
+		},
+		{
+			name:       "MONGODB-AWS with only a username (access key id)",
+			cfg:        ClientConfig{DB: "$external", AuthMechanism: "MONGODB-AWS", Username: "AKIAEXAMPLE"},
+			wantOK:     true,
+			wantMech:   "MONGODB-AWS",
+			wantUser:   "AKIAEXAMPLE",
+			wantSource: "$external",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			cred, ok := buildCredential(&cfg)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if cred.AuthMechanism != tc.wantMech {
+				t.Errorf("AuthMechanism = %q, want %q", cred.AuthMechanism, tc.wantMech)
+			}
+			if cred.Username != tc.wantUser {
+				t.Errorf("Username = %q, want %q", cred.Username, tc.wantUser)
+			}
+			if cred.Password != tc.wantPass {
+				t.Errorf("Password = %q, want %q", cred.Password, tc.wantPass)
+			}
+			if cred.PasswordSet != tc.wantPassSet {
+				t.Errorf("PasswordSet = %v, want %v", cred.PasswordSet, tc.wantPassSet)
+			}
+			if cred.AuthSource != tc.wantSource {
+				t.Errorf("AuthSource = %q, want %q", cred.AuthSource, tc.wantSource)
+			}
+			if tc.wantProps != nil && !reflect.DeepEqual(cred.AuthMechanismProperties, tc.wantProps) {
+				t.Errorf("AuthMechanismProperties = %v, want %v", cred.AuthMechanismProperties, tc.wantProps)
+			}
+		})
+	}
+}

--- a/mongodb/framework.go
+++ b/mongodb/framework.go
@@ -63,6 +63,12 @@ func (p *frameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
 			"direct":               schema.BoolAttribute{Optional: true, Description: "enforces a direct connection instead of discovery"},
 			"retrywrites":          schema.BoolAttribute{Optional: true, Description: "Retryable Writes"},
 			"proxy":                schema.StringAttribute{Optional: true},
+			"auth_mechanism":       schema.StringAttribute{Optional: true, Description: "The SASL authentication mechanism the provider uses to connect (e.g. SCRAM-SHA-256, MONGODB-X509, MONGODB-AWS, MONGODB-OIDC). Empty lets the driver negotiate SCRAM."},
+			"auth_mechanism_properties": schema.MapAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "Additional properties for the selected auth_mechanism, e.g. ENVIRONMENT and TOKEN_RESOURCE for MONGODB-OIDC or AWS_SESSION_TOKEN for MONGODB-AWS.",
+			},
 		},
 	}
 }
@@ -81,6 +87,8 @@ type frameworkProviderModel struct {
 	Direct             types.Bool   `tfsdk:"direct"`
 	RetryWrites        types.Bool   `tfsdk:"retrywrites"`
 	Proxy              types.String `tfsdk:"proxy"`
+	AuthMechanism      types.String `tfsdk:"auth_mechanism"`
+	AuthMechanismProps types.Map    `tfsdk:"auth_mechanism_properties"`
 }
 
 func (p *frameworkProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
@@ -106,6 +114,16 @@ func (p *frameworkProvider) Configure(ctx context.Context, req provider.Configur
 		Direct:             cfg.Direct.ValueBool(),
 		RetryWrites:        boolDefault(cfg.RetryWrites, true),
 		Proxy:              strDefault(cfg.Proxy, envMultiDefault("ALL_PROXY", "all_proxy")),
+		AuthMechanism:      strDefault(cfg.AuthMechanism, envDefault("MONGO_AUTH_MECHANISM", "")),
+	}
+
+	if !cfg.AuthMechanismProps.IsNull() && !cfg.AuthMechanismProps.IsUnknown() {
+		props := make(map[string]string, len(cfg.AuthMechanismProps.Elements()))
+		resp.Diagnostics.Append(cfg.AuthMechanismProps.ElementsAs(ctx, &props, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		clientConfig.AuthMechanismProperties = props
 	}
 
 	mc := &MongoDatabaseConfiguration{Config: &clientConfig, MaxConnLifetime: 10}

--- a/mongodb/provider.go
+++ b/mongodb/provider.go
@@ -95,6 +95,18 @@ func Provider() *schema.Provider {
 				}, nil),
 				ValidateDiagFunc: validateDiagFunc(validation.StringMatch(regexp.MustCompile(`^socks5h?://.*:\d+$`), "The proxy URL is not a valid socks url.")),
 			},
+			"auth_mechanism": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("MONGO_AUTH_MECHANISM", ""),
+				Description: "The SASL authentication mechanism the provider uses to connect (e.g. SCRAM-SHA-256, MONGODB-X509, MONGODB-AWS, MONGODB-OIDC). Empty lets the driver negotiate SCRAM.",
+			},
+			"auth_mechanism_properties": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Additional properties for the selected auth_mechanism, e.g. ENVIRONMENT and TOKEN_RESOURCE for MONGODB-OIDC or AWS_SESSION_TOKEN for MONGODB-AWS.",
+			},
 		},
 		// All resources are now served by the terraform-plugin-framework half
 		// (see framework_*.go), muxed alongside this SDKv2 provider. They must
@@ -128,6 +140,15 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		Direct:             d.Get("direct").(bool),
 		RetryWrites:        d.Get("retrywrites").(bool),
 		Proxy:              d.Get("proxy").(string),
+		AuthMechanism:      d.Get("auth_mechanism").(string),
+	}
+
+	if props, ok := d.GetOk("auth_mechanism_properties"); ok {
+		raw := props.(map[string]interface{})
+		clientConfig.AuthMechanismProperties = make(map[string]string, len(raw))
+		for k, v := range raw {
+			clientConfig.AuthMechanismProperties[k] = v.(string)
+		}
 	}
 
 	return &MongoDatabaseConfiguration{

--- a/mongodb/provider_auth_test.go
+++ b/mongodb/provider_auth_test.go
@@ -1,0 +1,57 @@
+package mongodb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccProvider_authMechanismSCRAM exercises the provider-level auth_mechanism
+// end to end: it forces the provider's own connection to authenticate with an
+// explicit SCRAM-SHA-256 mechanism (rather than letting the driver negotiate)
+// and confirms it can still create a user. This is the mechanism plumbing that
+// unlocks MONGODB-X509/AWS/OIDC, which CI cannot run against community mongo.
+func TestAccProvider_authMechanismSCRAM(t *testing.T) {
+	dbName := acctest.RandomWithPrefix("tf-acc-db")
+	userName := acctest.RandomWithPrefix("tf-acc-user")
+	resourceName := "mongodb_db_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMongoDBUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderAuthMechanismSCRAM(dbName, userName, "acc-pass-1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBUserExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", userName),
+				),
+			},
+		},
+	})
+}
+
+// testAccProviderAuthMechanismSCRAM sets auth_mechanism on the provider block;
+// host/port/username/password resolve from the environment defaults the other
+// acceptance tests rely on.
+func testAccProviderAuthMechanismSCRAM(dbName, userName, password string) string {
+	return fmt.Sprintf(`
+provider "mongodb" {
+  auth_mechanism = "SCRAM-SHA-256"
+}
+
+resource "mongodb_db_user" "test" {
+  auth_database = %[1]q
+  name          = %[2]q
+  password      = %[3]q
+
+  role {
+    db   = %[1]q
+    role = "readWrite"
+  }
+}
+`, dbName, userName, password)
+}


### PR DESCRIPTION
Adds provider-level `auth_mechanism` and `auth_mechanism_properties` config, plumbed into the driver's `options.Credential`. This unlocks SASL mechanisms beyond the previously hard-coded SCRAM path for the provider's **own** connection:

```hcl
provider "mongodb" {
  host          = "mongo.example.internal"
  auth_database = "$external"
  auth_mechanism = "MONGODB-OIDC"
  auth_mechanism_properties = {
    ENVIRONMENT    = "gcp"
    TOKEN_RESOURCE = "https://mongo.example.internal"
  }
}
```

### What changed
- `ClientConfig` gains `AuthMechanism` + `AuthMechanismProperties`; credential assembly moves into a testable `buildCredential` helper.
- The auth guard is widened: previously a credential was only set when **both** username and password were present. Now a credential is also built when an explicit mechanism is set, so passwordless mechanisms (X.509, OIDC with `ENVIRONMENT`, AWS IAM roles) authenticate. Existing username+password (SCRAM) behavior is unchanged.
- Both provider halves get the matching attributes (SDKv2 `TypeMap` ↔ framework `MapAttribute(String)`) — the mux requires identical config schemas; verified by the existing `TestMux*` tests.

### Testing
- `TestBuildCredential` unit-tests credential construction across SCRAM / X.509 / AWS / OIDC (the coverage available for mechanisms CI can't run live).
- `TestAccProvider_authMechanismSCRAM` exercises the mechanism plumbing **end-to-end** by forcing the provider's connection to use explicit `SCRAM-SHA-256`, then creating a user.

**Honest scope note:** SCRAM-SHA-256 is the only mechanism exercisable against the community `mongo:7` CI container. X.509/AWS/OIDC require external infra (client certs / IAM / an IdP) and a client-keypair TLS surface the provider doesn't yet expose, so they ship with construction-level unit coverage only — not a live acceptance test. Full acceptance suite passes locally (the new tests + all pre-existing tests).

Completes the provider-auth item from the gap analysis (after `authentication_restriction` in #35/#36).

🤖 Generated with [Claude Code](https://claude.com/claude-code)