### PR TITLE
feat(db_index): support sparse indexes

### DIFF
--- a/docs/resources/database_index.md
+++ b/docs/resources/database_index.md
@@ -22,7 +22,11 @@ resource "mongodb_db_index" "example_index" {
   keys {
     field = "unique"
     value = "true"
-  }  
+  }
+  keys {
+    field = "sparse"
+    value = "true"
+  }
   keys {
     field = "expireAfterSeconds"
     value = "86400"
@@ -80,8 +84,12 @@ resource "mongodb_db_index" "hidden_index" {
 ## Argument Reference
 * `db` - (Required) Database in which the target collection resides
 * `collection` - (Required) Collection name
-* `keys` - (Required) Field and value pairs where the field is the index key and the value describes the type of index for that field
-                      For an ascending index on a field, specify a value of 1. For descending index, specify a value of -1
+* `keys` - (Required) Field and value pairs where the field is the index key and the value describes the type of index for that field.
+                      For an ascending index on a field, specify a value of 1. For descending index, specify a value of -1.
+                      A handful of index *options* are also expressed as `keys` entries (rather than dedicated attributes):
+                      `unique = "true"`, `sparse = "true"`, and `expireAfterSeconds = "<n>"` (TTL). These are read back
+                      as `keys` entries too, appended after the real key fields in the order unique, sparse, expireAfterSeconds —
+                      list them last, in that order, to avoid a plan diff.
                       See https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndex/ for details
 * `name` - (Optional) Index name
 * `partial_filter_expression` - (Optional) A JSON string representing the partialFilterExpression for a partial index. Use `jsonencode()` for readability. See https://www.mongodb.com/docs/manual/core/index-partial/ for details

--- a/mongodb/framework_db_index.go
+++ b/mongodb/framework_db_index.go
@@ -292,6 +292,9 @@ func (r *dbIndexResource) createIndex(ctx context.Context, client *mongo.Client,
 		if strings.ToLower(keyField) == "unique" && (strings.ToLower(value) == "true" || strings.ToLower(value) == "false") {
 			indexOptions.SetUnique(strings.ToLower(value) == "true")
 			continue
+		} else if strings.ToLower(keyField) == "sparse" && (strings.ToLower(value) == "true" || strings.ToLower(value) == "false") {
+			indexOptions.SetSparse(strings.ToLower(value) == "true")
+			continue
 		} else if value == "1" {
 			indexKeys = append(indexKeys, bson.E{Key: keyField, Value: 1})
 		} else if value == "-1" {
@@ -364,6 +367,9 @@ func (r *dbIndexResource) readIndexInto(client *mongo.Client, m *dbIndexResource
 		}
 		if unique, ok := result["unique"]; ok {
 			keyValues = append(keyValues, mustIndexKeyObject("unique", fmt.Sprintf("%v", unique)))
+		}
+		if sparse, ok := result["sparse"]; ok {
+			keyValues = append(keyValues, mustIndexKeyObject("sparse", fmt.Sprintf("%v", sparse)))
 		}
 		if expireAfter, ok := result["expireAfterSeconds"]; ok {
 			keyValues = append(keyValues, mustIndexKeyObject("expireAfterSeconds", fmt.Sprintf("%v", expireAfter)))

--- a/mongodb/resource_db_index_test.go
+++ b/mongodb/resource_db_index_test.go
@@ -18,9 +18,9 @@ func TestAccMongoDBIndex_Basic(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexBasic(databaseName, collectionName, indexName),
@@ -51,9 +51,9 @@ func TestAccMongoDBIndex_MultipleFields(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexMultipleFields(databaseName, collectionName, indexName),
@@ -86,9 +86,9 @@ func TestAccMongoDBIndex_Compound(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexCompound(databaseName, collectionName, indexName),
@@ -117,9 +117,9 @@ func TestAccMongoDBIndex_TTLIndex(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexTTL(databaseName, collectionName, indexName),
@@ -151,9 +151,9 @@ func TestAccMongoDBIndex_GeneratedName(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexGeneratedName(databaseName, collectionName),
@@ -177,9 +177,9 @@ func TestAccMongoDBIndex_Unique(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexUnique(databaseName, collectionName, indexName),
@@ -209,6 +209,41 @@ func TestAccMongoDBIndex_Unique(t *testing.T) {
 	})
 }
 
+func TestAccMongoDBIndex_Sparse(t *testing.T) {
+	var indexName = acctest.RandomWithPrefix("tf-acc-sparse-idx")
+	var collectionName = acctest.RandomWithPrefix("tf-acc-coll")
+	var databaseName = acctest.RandomWithPrefix("tf-acc-db")
+	resourceName := "mongodb_db_index.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBIndexSparse(databaseName, collectionName, indexName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMongoDBIndexExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", indexName),
+					// read-back order: real keys, then unique, then sparse
+					resource.TestCheckResourceAttr(resourceName, "keys.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "keys.0.field", "email"),
+					resource.TestCheckResourceAttr(resourceName, "keys.1.field", "unique"),
+					resource.TestCheckResourceAttr(resourceName, "keys.1.value", "true"),
+					resource.TestCheckResourceAttr(resourceName, "keys.2.field", "sparse"),
+					resource.TestCheckResourceAttr(resourceName, "keys.2.value", "true"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"timeout"},
+			},
+		},
+	})
+}
+
 func TestAccMongoDBIndex_PartialFilter(t *testing.T) {
 	var indexName = acctest.RandomWithPrefix("tf-acc-partial-idx")
 	var collectionName = acctest.RandomWithPrefix("tf-acc-coll")
@@ -216,9 +251,9 @@ func TestAccMongoDBIndex_PartialFilter(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexPartialFilter(databaseName, collectionName, indexName),
@@ -254,9 +289,9 @@ func TestAccMongoDBIndex_PartialFilterElemMatch(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexPartialFilterExists(databaseName, collectionName, indexName),
@@ -282,9 +317,9 @@ func TestAccMongoDBIndex_Hidden(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexHidden(databaseName, collectionName, indexName, true),
@@ -312,9 +347,9 @@ func TestAccMongoDBIndex_HiddenToggle(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			// Step 1: create index as visible (hidden=false)
 			{
@@ -354,9 +389,9 @@ func TestAccMongoDBIndex_PartialFilterAndHidden(t *testing.T) {
 	resourceName := "mongodb_db_index.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		CheckDestroy:      testAccCheckMongoDBIndexDestroy,
+		CheckDestroy:             testAccCheckMongoDBIndexDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMongoDBIndexPartialFilterAndHidden(databaseName, collectionName, indexName),
@@ -710,6 +745,36 @@ resource "mongodb_db_index" "test" {
   }
   keys {
     field = "unique"
+    value = "true"
+  }
+  timeout = 30
+}
+`, dbName, collectionName, dbName, collectionName, indexName)
+}
+
+func testAccMongoDBIndexSparse(dbName, collectionName, indexName string) string {
+	return fmt.Sprintf(`
+resource "mongodb_db_collection" "test" {
+  db                   = "%s"
+  name                 = "%s"
+  deletion_protection  = false
+}
+
+resource "mongodb_db_index" "test" {
+  depends_on = [mongodb_db_collection.test]
+  db         = "%s"
+  collection = "%s"
+  name       = "%s"
+  keys {
+    field = "email"
+    value = "1"
+  }
+  keys {
+    field = "unique"
+    value = "true"
+  }
+  keys {
+    field = "sparse"
     value = "true"
   }
   timeout = 30


### PR DESCRIPTION
Adds `sparse` index support to `mongodb_db_index`, using the same `keys`-entry idiom the provider already uses for `unique` and `expireAfterSeconds`:

```hcl
keys {
  field = "email"
  value = "1"
}
keys {
  field = "sparse"
  value = "true"
}
```

**Why:** `sparse` was the only genuinely missing option of the three in the gap analysis — `unique` and `expireAfterSeconds` already work via `keys` entries. Worse, before this change a `keys` entry with `field = "sparse"` fell through the create logic and created an index on a *literal field named "sparse"*. Now it maps to the driver's `SetSparse`.

- Read-back appends the `sparse` pseudo-entry after `unique` (order: real keys → unique → sparse → expireAfterSeconds), so the value round-trips with no plan diff.
- `TestAccMongoDBIndex_Sparse` covers create + import round-trip; `Unique`/`TTL` tests confirm no regression (verified locally against mongo:7).
- Documented in the argument reference + example.

Kept consistent with the shipped v3 `keys`-based contract rather than introducing first-class `unique`/`sparse` attributes, which would break existing configs (state shape change → perpetual diffs). Promoting index options to dedicated attributes would be a v4 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)